### PR TITLE
Flask-cli command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Switch to `flask-cli` and endpoint-based commands (requires `udata>=1.3`)
+- Switch to `flask-cli` and endpoint-based commands (requires `udata>=1.3`) [#33](https://github.com/opendatateam/udata-piwik/pull/33)
 
 ## 1.0.2 (2017-12-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Switch to `flask-cli` and endpoint-based commands (requires `udata>=1.3`)
 
 ## 1.0.2 (2017-12-20)
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,1 +1,1 @@
-udata>=1.2.5
+udata>=1.3.0.dev

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -1,4 +1,4 @@
-pytest-catchlog==1.2.2
+mock==2.0.0
 pytest-flask==0.10.0
 pytest-mock==1.6.3
 retrying==1.3.3

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -1,2 +1,4 @@
+pytest-catchlog==1.2.2
 pytest-flask==0.10.0
+pytest-mock==1.6.3
 retrying==1.3.3

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,11 @@ setup(
     extras_require={
         'test': tests_require,
     },
+    entry_points={
+        'udata.commands': [
+            'piwik = udata_piwik.commands:piwik',
+        ],
+    },
     license='LGPL',
     zip_safe=False,
     keywords='udata piwik',

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ tests_require = pip('test.pip')
 
 setup(
     name='udata-piwik',
-    version='1.0.3.dev',
+    version='1.1.0.dev',
     description='Piwik support for uData',
     long_description=long_description,
     url='https://github.com/opendatateam/udata-piwik',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ MODULES = ['core.dataset', 'core.organization', 'core.user', 'core.reuse',
 
 
 class PiwikSettings(Testing):
+    PLUGINS = ['piwik']
     PIWIK_ID = 1
     PIWIK_URL = os.environ.get('PIWIK_URL', 'localhost:8080')
     PIWIK_AUTH = 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
@@ -31,7 +32,6 @@ class PiwikSettings(Testing):
 
 @pytest.fixture(scope='module')  # noqa
 def app():
-    reload(sys).setdefaultencoding('ascii')
     app = create_app(settings.Defaults, override=PiwikSettings)
     frontend.init_app(app, MODULES)
     return app

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+from datetime import date, timedelta
+
+from click.testing import CliRunner
+from udata.commands import cli
+
+
+@pytest.fixture
+def cmd(mocker, app):
+    def mock_runner(args):
+        runner = CliRunner()
+        return runner.invoke(cli, ['piwik'] + args.split())
+
+    # Mock counter to speedup test as it is already tested elsewhere
+    mock_runner.counter = mocker.patch('udata_piwik.commands.counter')
+    # Avoid to instanciate another app and reuse the app fixture
+    mocker.patch.object(cli, 'create_app', return_value=app)
+    return mock_runner
+
+
+def test_command_without_parameters(cmd):
+    result = cmd('fill')
+
+    assert result.exit_code == 0, result.output_bytes
+    cmd.counter.count_for.assert_called_once_with(date.today())
+
+
+def test_command_with_start_date(cmd):
+    days = 3
+    start_date = date.today() - timedelta(days=days)
+    result = cmd('fill -s {0:%Y-%m-%d}'.format(start_date))
+
+    assert result.exit_code == 0, result.output_bytes
+
+    assert cmd.counter.count_for.call_count == days + 1
+
+    for delta in range(days + 1):
+        param = start_date + timedelta(days=delta)
+        cmd.counter.count_for.assert_any_call(param)
+
+
+def test_command_with_end_date(cmd):
+    end_date = date.today() - timedelta(days=3)
+    result = cmd('fill -e {0:%Y-%m-%d}'.format(end_date))
+
+    assert result.exit_code == 0, result.output_bytes
+    cmd.counter.count_for.assert_called_once_with(end_date)
+
+
+def test_command_with_start_and_end_date(cmd):
+    days = 3
+    start_date = date.today() - timedelta(days=days)
+    end_date = date.today() - timedelta(days=1)
+    result = cmd(
+        'fill -s {0:%Y-%m-%d} -e {1:%Y-%m-%d}'.format(start_date, end_date)
+    )
+
+    assert result.exit_code == 0, result.output_bytes
+
+    assert cmd.counter.count_for.call_count == days
+
+    for delta in range(days):
+        param = start_date + timedelta(days=delta)
+        cmd.counter.count_for.assert_any_call(param)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -17,7 +17,7 @@ def cmd(mocker, app):
 
     # Mock counter to speedup test as it is already tested elsewhere
     mock_runner.counter = mocker.patch('udata_piwik.commands.counter')
-    # Avoid to instanciate another app and reuse the app fixture
+    # Avoid instanciating another app and reuse the app fixture
     mocker.patch.object(cli, 'create_app', return_value=app)
     return mock_runner
 

--- a/tests/test_piwik.py
+++ b/tests/test_piwik.py
@@ -13,7 +13,7 @@ from udata.core.post.factories import PostFactory
 from udata.core.reuse.factories import ReuseFactory
 from udata.core.user.factories import UserFactory
 
-from udata_piwik.commands import fill
+from udata_piwik.counter import counter
 
 from .client import visit, has_data, reset, download
 
@@ -77,7 +77,7 @@ def fixtures(clean_db, reset_piwik, dataset_resource, organization,
              user, reuse, post, community_resource):
     # wait for Piwik to be populated
     assert has_data()
-    fill()
+    counter.count_for(date.today())
     dataset, resource = dataset_resource
     return {
         'dataset': dataset,

--- a/udata_piwik/commands.py
+++ b/udata_piwik/commands.py
@@ -3,9 +3,11 @@ from __future__ import unicode_literals
 
 import logging
 
+import click
+
 from datetime import date, timedelta
 
-from udata.commands import submanager
+from udata.commands import cli, success
 
 from .counter import counter
 
@@ -13,29 +15,45 @@ from .counter import counter
 log = logging.getLogger(__name__)
 
 
-m = submanager(
-    'piwik',
-    help='Piwik related operations',
-    description='Handle all Piwik related operations'
-)
+@cli.group()
+def piwik():
+    '''Piwik related operations'''
+    pass
 
 
-def parse_date(string):
-    if string:
-        parts = [int(s) for s in string.strip().split('-')]
-        return date(*parts)
+class DateParamType(click.ParamType):
+    name = 'date'
+
+    def convert(self, value, param, ctx):
+        if not value:
+            return
+        if isinstance(value, date):
+            return value
+        try:
+            parts = [int(s) for s in value.strip().split('-')]
+            return date(*parts)
+        except ValueError:
+            self.fail('%s is not a valid date' % value, param, ctx)
 
 
-@m.command
-def fill(start=None, end=None):
+DATE = DateParamType()
+
+
+@piwik.command()
+@click.option('-s', '--start', type=DATE, default=None,
+              help='The start of the period to fill')
+@click.option('-e', '--end', type=DATE, default=date.today,
+              help='The end of the period to fill')
+def fill(start, end):
     '''Fill the piwik metrics'''
-    end = parse_date(end) or date.today()
-    start = parse_date(start) or end
+    start = start or end
     log.info('Loading metrics from {start} to {end}'.format(start=start, end=end))
 
     current_date = start
 
     while current_date <= end:
-        log.info(str(current_date))
+        log.info('Processing %s', current_date)
         counter.count_for(current_date)
         current_date += timedelta(days=1)
+
+    success('Loaded all metrics on the period')

--- a/udata_piwik/commands.py
+++ b/udata_piwik/commands.py
@@ -56,4 +56,4 @@ def fill(start, end):
         counter.count_for(current_date)
         current_date += timedelta(days=1)
 
-    success('Loaded all metrics on the period')
+    success('Loaded all metrics for the period')


### PR DESCRIPTION
This PR switch to `flask-cli`/entrypoint-based commands and is connected to opendatateam/udata#1364

Switching to flask-cli allows proper command testing using the click `CliRunner`