### PR TITLE
Refactor `counter.handle_downloads`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current (in progress)
 
+- Refactor `counter.handle_downloads` - fix [#1421](https://github.com/opendatateam/udata/issues/1421)
 - Switch to `flask-cli` and endpoint-based commands (requires `udata>=1.3`) [#33](https://github.com/opendatateam/udata-piwik/pull/33)
 
 ## 1.0.2 (2017-12-20)


### PR DESCRIPTION
This prevents https://github.com/opendatateam/udata-piwik/compare/master...abulte:fix/udata-gh-%231421-downloads?expand=1#diff-79ff71b7843baac1cf70d8088e201924L179 from randomly returning a dataset with a deleted resource.

This should also make the code a bit easier to read. We probably still need a complete refactoring though.