### PR TITLE
Fixes missing udata.views entrypoint and failing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Refactor `counter.handle_downloads` - fix [#1421](https://github.com/opendatateam/udata/issues/1421)
 - Switch to `flask-cli` and endpoint-based commands (requires `udata>=1.3`) [#33](https://github.com/opendatateam/udata-piwik/pull/33)
 - Expose the new `udata.tasks` endpoint [#39](https://github.com/opendatateam/udata-piwik/pull/39)
+- Expose the new `udata.views` endpoint [#41](https://github.com/opendatateam/udata-piwik/pull/41)
 
 ## 1.0.2 (2017-12-20)
 

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,9 @@ setup(
         'udata.tasks': [
             'piwik = udata_piwik.tasks',
         ],
+        'udata.views': [
+            'piwik = udata_piwik.views',
+        ],
     },
     license='LGPL',
     zip_safe=False,

--- a/tests/test_piwik.py
+++ b/tests/test_piwik.py
@@ -25,7 +25,7 @@ from .client import visit, has_data, reset, download
 
 
 MODULES = ['core.dataset', 'core.organization', 'core.user', 'core.reuse',
-           'core.discussions', 'core.post']
+           'core.post']
 
 
 @pytest.fixture(scope='module')  # noqa

--- a/udata_piwik/__init__.py
+++ b/udata_piwik/__init__.py
@@ -1,17 +1,2 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-
-from flask import render_template, Blueprint
-
-from udata.frontend import footer_snippet
-
-blueprint = Blueprint('piwik', __name__, template_folder='templates')
-
-
-def init_app(app):
-    from . import metrics  # noqa: F401
-    app.register_blueprint(blueprint)
-
-    @footer_snippet
-    def render_piwik_snippet():
-        return render_template('piwik.html')

--- a/udata_piwik/views.py
+++ b/udata_piwik/views.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from flask import render_template, Blueprint
+
+from udata.frontend import footer_snippet
+
+blueprint = Blueprint('piwik', __name__, template_folder='templates')
+
+
+@footer_snippet
+def render_piwik_snippet():
+    return render_template('piwik.html')


### PR DESCRIPTION
This PR exposes the required blueprint as `udata.views` entrypoint