### PR TITLE
Handle multiple resource for same url - fix #48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Handle multiple resources for same url [#49](https://github.com/opendatateam/udata-piwik/pull/49)
 
 ## 1.1.0 (2018-03-13)
 

--- a/udata_piwik/counter.py
+++ b/udata_piwik/counter.py
@@ -2,80 +2,25 @@
 from __future__ import unicode_literals
 
 import logging
-import re
-import uuid
-
-from datetime import date
-
-from flask import _app_ctx_stack
 
 from werkzeug.exceptions import NotFound
-from werkzeug.routing import RequestRedirect
-from werkzeug.urls import url_parse
 
-from udata.core.metrics.models import Metrics
-from udata.models import (
-    User, Organization, Reuse, Dataset, CommunityResource
-)
-from udata.utils import hash_url, get_by
+from udata.models import User, Organization, Reuse, Dataset
 
 from .client import analyze
+from .download_counter import DailyDownloadCounter
 from .metrics import (
-    DatasetViews, ResourceViews, ReuseViews, OrganizationViews, UserViews,
-    OrgDatasetsViews, OrgResourcesDownloads, OrgReusesViews,
-    CommunityResourceViews,
-    aggregate_datasets_daily, aggregate_reuses_daily
+    DatasetViews, ReuseViews, OrganizationViews, UserViews, OrgDatasetsViews,
+    OrgReusesViews, aggregate_datasets_daily, aggregate_reuses_daily,
+    upsert_metric_for_day, clear_metrics_for_day,
 )
+from .utils import is_today, route_from, RouteNotFound
 
 log = logging.getLogger(__name__)
 
-LATEST_URL_REGEX = 'http[s]?://.*/datasets/r/([0-9a-f-]{36})[/]?$'
-
-
-class RouteNotFound(Exception):
-    pass
-
-
-def route_from(url, method=None):
-    appctx = _app_ctx_stack.top
-    if appctx is None:
-        raise RuntimeError('Attempted to match a URL without the '
-                           'application context being pushed. This has to be '
-                           'executed when application context is available.')
-
-    url_adapter = appctx.url_adapter
-    if url_adapter is None:
-        raise RuntimeError('Application was not able to create a URL '
-                           'adapter for request independent URL matching. '
-                           'You might be able to fix this by setting '
-                           'the SERVER_NAME config variable.')
-    parsed_url = url_parse(url)
-    if parsed_url.netloc is not "" and parsed_url.netloc != url_adapter.server_name:
-        raise RouteNotFound
-
-    try:
-        url_adapter.path_info = url_adapter.path_info or parsed_url.path
-        url_adapter.query_args = url_adapter.query_args or parsed_url.decode_query()
-        return url_adapter.match(parsed_url.path, method)
-    except RequestRedirect as re:
-        return route_from(re.new_url, method)
-
-
-_routes = {}
-
-KEYS = 'nb_uniq_visitors nb_hits nb_visits'.split()
-
-
-def is_today(day):
-    today = date.today()
-    if isinstance(day, basestring):
-        return day == today.isoformat()
-    else:
-        return day == today
-
 
 class Counter(object):
-    '''Perform reverse routing and count for daily stats'''
+    '''Handle view count and delegate download count to DailyDownloadCounter'''
     def __init__(self):
         self.routes = {}
 
@@ -85,51 +30,11 @@ class Counter(object):
             return func
         return wrapper
 
-    def clear(self, day):
-        if not isinstance(day, basestring):
-            day = (day or date.today()).isoformat()
-
-        if is_today(day):
-            commands = dict(('set__metrics__{0}'.format(k), 0) for k in KEYS)
-            for model in Organization, Reuse, User:
-                try:
-                    model.objects.update(**commands)
-                except Exception:
-                    log.exception('Unable to clean %s', model.__name__)
-            for dataset in Dataset.objects:
-                dcommands = commands.copy()
-                for i, _ in enumerate(dataset.resources):
-                    dcommands.update({
-                        'set__resources__{0}__metrics__{1}'.format(i, k): 0
-                        for k in KEYS
-                    })
-                try:
-                    dataset.update(**dcommands)
-                except Exception:
-                    log.exception('Unable to clear dataset %s', dataset.id)
-
-        commands = dict(('unset__values__{0}'.format(k), '1') for k in KEYS)
-        metrics = Metrics.objects(level='daily', date=day)
-        return metrics.update(upsert=False, **commands)
-
-    def count(self, obj, day, data):
-        oid = obj.id if hasattr(obj, 'id') else obj
-        if not isinstance(day, basestring):
-            day = (day or date.today()).isoformat()
-
-        if hasattr(obj, 'metrics') and day == date.today().isoformat():
-            # Update object current metrics
-            for k in KEYS:
-                obj.metrics[k] = data[k]
-
-        commands = dict(('inc__values__{0}'.format(k), data[k]) for k in KEYS)
-        metrics = Metrics.objects(object_id=oid, level='daily', date=day)
-        return metrics.update_one(upsert=True, **commands)
-
     def count_for(self, day):
-        self.clear(day)
+        clear_metrics_for_day(day)
         self.count_views(day)
-        self.count_downloads(day)
+        dl_counter = DailyDownloadCounter(day)
+        dl_counter.count()
 
     def count_views(self, day):
         params = {
@@ -139,17 +44,6 @@ class Counter(object):
         }
         for row in analyze('Actions.getPageUrls', **params):
             self.handle_views(row, day)
-
-    def count_downloads(self, day):
-        params = {
-            'period': 'day',
-            'date': day,
-            'expanded': 1
-        }
-        for row in analyze('Actions.getDownloads', **params):
-            self.handle_downloads(row, day)
-        for row in analyze('Actions.getOutlinks', **params):
-            self.handle_downloads(row, day)
 
     def handle_views(self, row, day):
         if 'url' in row:
@@ -168,70 +62,6 @@ class Counter(object):
             for subrow in row['subtable']:
                 self.handle_views(subrow, day)
 
-    def get_downloaded_object(self, hashed_url, resource_id=None):
-        if resource_id:
-            try:
-                data = Dataset.objects.get(resources__id=resource_id)
-                resource = get_by(data.resources, 'id', uuid.UUID(resource_id))
-            except Dataset.DoesNotExist:
-                try:
-                    data = CommunityResource.objects.get(id=resource_id)
-                    resource = data
-                except CommunityResource.DoesNotExist:
-                    raise Exception('No object found for resource_id %s' %
-                                    resource_id)
-        else:
-            try:
-                data = Dataset.objects.get(resources__urlhash=hashed_url)
-                resource = get_by(data.resources, 'urlhash', hashed_url)
-            except Dataset.DoesNotExist:
-                try:
-                    data = CommunityResource.objects.get(urlhash=hashed_url)
-                    resource = data
-                except CommunityResource.DoesNotExist:
-                    raise Exception('No object found for urlhash %s' %
-                                    hashed_url)
-
-        return data, resource
-
-    def handle_download(self, data, resource, day, row):
-        if isinstance(data, Dataset):
-            dataset = data
-            log.debug('Found resource download: %s', resource.url)
-            self.count(resource, day, row)
-            metric = ResourceViews(resource)
-            metric.compute()
-            # Use the MongoDB positionnal operator ($)
-            cmd = 'set__resources__S__metrics__{0}'.format(metric.name)
-            qs = Dataset.objects(id=dataset.id,
-                                 resources__id=resource.id)
-            qs.update(**{cmd: metric.value})
-            if dataset.organization:
-                OrgResourcesDownloads(dataset.organization).compute()
-        elif isinstance(data, CommunityResource):
-            log.debug('Found community resource download: %s',
-                      resource.url)
-            self.count(resource, day, row)
-            metric = CommunityResourceViews(resource)
-            metric.compute()
-            resource.metrics[metric.name] = metric.value
-            resource.save()
-
-    def handle_downloads(self, row, day):
-        if 'url' in row:
-            try:
-                hashed_url = hash_url(row['url'])
-                last_url_match = re.match(LATEST_URL_REGEX, row['url'])
-                resource_id = last_url_match and last_url_match.group(1)
-                data, resource = self.get_downloaded_object(
-                    hashed_url, resource_id=resource_id)
-                self.handle_download(data, resource, day, row)
-            except Exception:
-                log.exception('Unable to count download for %s', row['url'])
-        if 'subtable' in row:
-            for subrow in row['subtable']:
-                self.handle_downloads(subrow, day)
-
 
 counter = Counter()
 
@@ -239,7 +69,7 @@ counter = Counter()
 @counter.route('datasets.show')
 def on_dataset_display(data, day, dataset, **kwargs):
     if isinstance(dataset, Dataset):
-        counter.count(dataset, day, data)
+        upsert_metric_for_day(dataset, day, data)
         if is_today(day):
             try:
                 dataset.save()
@@ -254,7 +84,7 @@ def on_dataset_display(data, day, dataset, **kwargs):
 @counter.route('reuses.show')
 def on_reuse_display(data, day, reuse, **kwargs):
     if isinstance(reuse, Reuse):
-        counter.count(reuse, day, data)
+        upsert_metric_for_day(reuse, day, data)
         if is_today(day):
             try:
                 reuse.save()
@@ -269,7 +99,7 @@ def on_reuse_display(data, day, reuse, **kwargs):
 @counter.route('organizations.show')
 def on_org_display(data, day, org, **kwargs):
     if isinstance(org, Organization):
-        counter.count(org, day, data)
+        upsert_metric_for_day(org, day, data)
         if is_today(day):
             try:
                 org.save()
@@ -281,7 +111,7 @@ def on_org_display(data, day, org, **kwargs):
 @counter.route('users.show')
 def on_user_display(data, day, user, **kwargs):
     if isinstance(user, User):
-        counter.count(user, day, data)
+        upsert_metric_for_day(user, day, data)
         if is_today(day):
             try:
                 user.save()

--- a/udata_piwik/download_counter.py
+++ b/udata_piwik/download_counter.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import logging
+import re
+import uuid
+
+from udata.models import Dataset, CommunityResource
+from udata.utils import hash_url, get_by
+
+from .client import analyze
+from .metrics import (
+    ResourceViews, OrgResourcesDownloads, CommunityResourceViews,
+    upsert_metric_for_day,
+)
+
+log = logging.getLogger(__name__)
+
+LATEST_URL_REGEX = 'http[s]?://.*/datasets/r/([0-9a-f-]{36})[/]?$'
+
+
+class DailyDownloadCounter(object):
+    '''Perform reverse routing and count for daily stats'''
+    def __init__(self, day):
+        self.day = day
+
+    def count(self):
+        self.count_downloads()
+
+    def count_downloads(self):
+        params = {
+            'period': 'day',
+            'date': self.day,
+            'expanded': 1
+        }
+        for row in analyze('Actions.getDownloads', **params):
+            self.handle_downloads(row)
+        for row in analyze('Actions.getOutlinks', **params):
+            self.handle_downloads(row)
+
+    def get_downloaded_object(self, hashed_url, resource_id=None):
+        if resource_id:
+            try:
+                data = Dataset.objects.get(resources__id=resource_id)
+                resource = get_by(data.resources, 'id', uuid.UUID(resource_id))
+            except Dataset.DoesNotExist:
+                try:
+                    data = CommunityResource.objects.get(id=resource_id)
+                    resource = data
+                except CommunityResource.DoesNotExist:
+                    raise Exception('No object found for resource_id %s' %
+                                    resource_id)
+        else:
+            try:
+                data = Dataset.objects.get(resources__urlhash=hashed_url)
+                resource = get_by(data.resources, 'urlhash', hashed_url)
+            except Dataset.DoesNotExist:
+                try:
+                    data = CommunityResource.objects.get(urlhash=hashed_url)
+                    resource = data
+                except CommunityResource.DoesNotExist:
+                    raise Exception('No object found for urlhash %s' %
+                                    hashed_url)
+
+        return data, resource
+
+    def handle_download(self, data, resource, row):
+        if isinstance(data, Dataset):
+            dataset = data
+            log.debug('Found resource download: %s', resource.url)
+            upsert_metric_for_day(resource, self.day, row)
+            metric = ResourceViews(resource)
+            metric.compute()
+            # Use the MongoDB positionnal operator ($)
+            cmd = 'set__resources__S__metrics__{0}'.format(metric.name)
+            qs = Dataset.objects(id=dataset.id,
+                                 resources__id=resource.id)
+            qs.update(**{cmd: metric.value})
+            if dataset.organization:
+                OrgResourcesDownloads(dataset.organization).compute()
+        elif isinstance(data, CommunityResource):
+            log.debug('Found community resource download: %s',
+                      resource.url)
+            upsert_metric_for_day(resource, self.day, row)
+            metric = CommunityResourceViews(resource)
+            metric.compute()
+            resource.metrics[metric.name] = metric.value
+            resource.save()
+
+    def handle_downloads(self, row):
+        if 'url' in row:
+            try:
+                hashed_url = hash_url(row['url'])
+                last_url_match = re.match(LATEST_URL_REGEX, row['url'])
+                resource_id = last_url_match and last_url_match.group(1)
+                data, resource = self.get_downloaded_object(
+                    hashed_url, resource_id=resource_id)
+                self.handle_download(data, resource, row)
+            except Exception:
+                log.exception('Unable to count download for %s', row['url'])
+        if 'subtable' in row:
+            for subrow in row['subtable']:
+                self.handle_downloads(subrow)

--- a/udata_piwik/metrics.py
+++ b/udata_piwik/metrics.py
@@ -245,6 +245,6 @@ def clear_metrics_for_day(day):
             except Exception:
                 log.exception('Unable to clear dataset %s', dataset.id)
 
-    commands = dict(('unset__values__{0}'.format(k), '1') for k in KEYS)
+    commands = dict(('unset__values__{0}'.format(k), 1) for k in KEYS)
     metrics = Metrics.objects(level='daily', date=day)
     return metrics.update(upsert=False, **commands)

--- a/udata_piwik/metrics.py
+++ b/udata_piwik/metrics.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 import itertools
 import logging
 
+from datetime import date
+
 from udata.core.metrics import Metric
 from udata.core.metrics.models import Metrics
 from udata.i18n import lazy_gettext as _
@@ -11,6 +13,10 @@ from udata.i18n import lazy_gettext as _
 from udata.models import (
     User, Organization, Reuse, Dataset, Resource, CommunityResource
 )
+
+from .utils import is_today
+
+KEYS = 'nb_uniq_visitors nb_hits nb_visits'.split()
 
 
 log = logging.getLogger(__name__)
@@ -183,9 +189,6 @@ class OrgReusesViews(Metric):
                           .sum('values.nb_uniq_visitors'))
 
 
-KEYS = 'nb_uniq_visitors nb_hits nb_visits'.split()
-
-
 def aggregate_datasets_daily(org, day):
     keys = ['datasets_{0}'.format(k) for k in KEYS]
     ids = [d.id for d in Dataset.objects(organization=org).only('id')]
@@ -202,3 +205,46 @@ def aggregate_reuses_daily(org, day):
                               level='daily', date=day.isoformat())
     values = [int(metrics.sum('values.{0}'.format(k))) for k in KEYS]
     Metrics.objects.update_daily(org, day, **dict(zip(keys, values)))
+
+
+def upsert_metric_for_day(obj, day, data):
+    oid = obj.id if hasattr(obj, 'id') else obj
+    if not isinstance(day, basestring):
+        day = (day or date.today()).isoformat()
+
+    if hasattr(obj, 'metrics') and day == date.today().isoformat():
+        # Update object current metrics
+        for k in KEYS:
+            obj.metrics[k] = data[k]
+
+    commands = dict(('inc__values__{0}'.format(k), data[k]) for k in KEYS)
+    metrics = Metrics.objects(object_id=oid, level='daily', date=day)
+    return metrics.update_one(upsert=True, **commands)
+
+
+def clear_metrics_for_day(day):
+    if not isinstance(day, basestring):
+        day = (day or date.today()).isoformat()
+
+    if is_today(day):
+        commands = dict(('set__metrics__{0}'.format(k), 0) for k in KEYS)
+        for model in Organization, Reuse, User:
+            try:
+                model.objects.update(**commands)
+            except Exception:
+                log.exception('Unable to clean %s', model.__name__)
+        for dataset in Dataset.objects:
+            dcommands = commands.copy()
+            for i, _r in enumerate(dataset.resources):
+                dcommands.update({
+                    'set__resources__{0}__metrics__{1}'.format(i, k): 0
+                    for k in KEYS
+                })
+            try:
+                dataset.update(**dcommands)
+            except Exception:
+                log.exception('Unable to clear dataset %s', dataset.id)
+
+    commands = dict(('unset__values__{0}'.format(k), '1') for k in KEYS)
+    metrics = Metrics.objects(level='daily', date=day)
+    return metrics.update(upsert=False, **commands)

--- a/udata_piwik/utils.py
+++ b/udata_piwik/utils.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from datetime import date
+
+from flask import _app_ctx_stack
+from werkzeug.routing import RequestRedirect
+from werkzeug.urls import url_parse
+
+
+class RouteNotFound(Exception):
+    pass
+
+
+def route_from(url, method=None):
+    appctx = _app_ctx_stack.top
+    if appctx is None:
+        raise RuntimeError('Attempted to match a URL without the '
+                           'application context being pushed. This has to be '
+                           'executed when application context is available.')
+
+    url_adapter = appctx.url_adapter
+    if url_adapter is None:
+        raise RuntimeError('Application was not able to create a URL '
+                           'adapter for request independent URL matching. '
+                           'You might be able to fix this by setting '
+                           'the SERVER_NAME config variable.')
+    parsed_url = url_parse(url)
+    if parsed_url.netloc is not "" and parsed_url.netloc != url_adapter.server_name:
+        raise RouteNotFound
+
+    try:
+        url_adapter.path_info = url_adapter.path_info or parsed_url.path
+        url_adapter.query_args = url_adapter.query_args or parsed_url.decode_query()
+        return url_adapter.match(parsed_url.path, method)
+    except RequestRedirect as re:
+        return route_from(re.new_url, method)
+
+
+def is_today(day):
+    today = date.today()
+    if isinstance(day, basestring):
+        return day == today.isoformat()
+    else:
+        return day == today


### PR DESCRIPTION
This PR:

- Refactors the `counter` logic by handling downloads in a separate class
- Handles the case of multiple resources with the same URL. Unfortunately we can not detect exactly what resource has been hit (in the case of `hashed_url` detection) so there will be some duplicate metrics across resources.