### PR TITLE
Simpler and more reliable metrics computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Handle multiple resources for same url [#49](https://github.com/opendatateam/udata-piwik/pull/49)
+- Simpler and more reliable metrics computation [#54](https://github.com/opendatateam/udata-piwik/pull/54)
 
 ## 1.1.0 (2018-03-13)
 

--- a/tests/test_piwik.py
+++ b/tests/test_piwik.py
@@ -42,7 +42,7 @@ def app(request):
 
 @pytest.fixture(scope='module')
 def dataset_resource():
-    resource = ResourceFactory()
+    resource = ResourceFactory(url='http://schéma.org')
     dataset = DatasetFactory(resources=[resource])
     # 2x visit
     visit(dataset)

--- a/tests/test_piwik.py
+++ b/tests/test_piwik.py
@@ -128,6 +128,8 @@ def fixtures(app, reset_piwik, dataset_resource, organization,
     # wait for Piwik to be populated
     assert has_data()
     counter.count_for(date.today())
+    # count twice to be ensure idempotence on one day
+    counter.count_for(date.today())
     dataset, resource = dataset_resource
     d_w_previous_data, r_w_previous_data = dataset_resource_w_previous_data
     return {

--- a/tests/test_piwik.py
+++ b/tests/test_piwik.py
@@ -65,6 +65,7 @@ def dataset_resource_w_previous_data():
     upsert_metric_for_day(resource, day, data)
     visit(dataset)
     download(resource)
+    download(resource, latest=True)
     return dataset, resource
 
 
@@ -186,7 +187,7 @@ def test_resource_metric(fixtures):
 def test_resource_metric_with_previous_data(fixtures):
     fixtures['dataset_w_previous_data'].reload()
     resource = fixtures['dataset_w_previous_data'].resources[0]
-    assert resource.metrics == {'views': 16}
+    assert resource.metrics == {'views': 17}
 
 
 def test_community_resource_metric(fixtures):

--- a/tests/test_piwik.py
+++ b/tests/test_piwik.py
@@ -157,6 +157,13 @@ def test_resource_metric(fixtures):
     # 1 hit on permalink, 1 on url
     assert metric.values == {'nb_hits': 2, 'nb_uniq_visitors': 2,
         'nb_visits': 2}
+    fixtures['resource'].reload()
+    assert fixtures['resource'].metrics == {
+        'nb_hits': 2,
+        'nb_uniq_visitors': 2,
+        'nb_visits': 2,
+        'views': 2,
+    }
 
 
 def test_community_resource_metric(fixtures):

--- a/udata_piwik/download_counter.py
+++ b/udata_piwik/download_counter.py
@@ -67,8 +67,7 @@ class DailyDownloadCounter(object):
                     'data': row,
                 })
             except CommunityResource.DoesNotExist:
-                raise Exception('No object found for resource_id %s' %
-                                resource_id)
+                log.error('No object found for resource_id %s' % resource_id)
 
     def detect_by_hashed_url(self, hashed_url, row):
         found = False
@@ -95,10 +94,12 @@ class DailyDownloadCounter(object):
         except CommunityResource.DoesNotExist:
             pass
         if not found:
-            raise Exception('No object found for urlhash %s' % hashed_url)
+            log.error('No object found for urlhash %s' % hashed_url)
 
     def detect_download_objects(self):
         for row in self.rows:
+            if 'url' not in row:
+                continue
             last_url_match = re.match(LATEST_URL_REGEX, row['url'])
             resource_id = last_url_match and last_url_match.group(1)
             if resource_id:

--- a/udata_piwik/metrics.py
+++ b/udata_piwik/metrics.py
@@ -14,108 +14,10 @@ from udata.models import (
     User, Organization, Reuse, Dataset, Resource, CommunityResource
 )
 
-from .utils import is_today
-
 KEYS = 'nb_uniq_visitors nb_hits nb_visits'.split()
 
 
 log = logging.getLogger(__name__)
-
-
-class HitsMetric(Metric):
-    name = 'nb_hits'
-    display_name = _('Hits')
-
-    def get_value(self):
-        pass
-
-
-class DatasetHits(HitsMetric):
-    model = Dataset
-
-
-class ResourceHits(HitsMetric):
-    model = Resource
-
-
-class CommunityResourceHits(HitsMetric):
-    model = CommunityResource
-
-
-class ReuseHits(HitsMetric):
-    model = Reuse
-
-
-class OrganizationHits(HitsMetric):
-    model = Organization
-
-
-class UserHits(HitsMetric):
-    model = User
-
-
-class VisitsMetric(Metric):
-    name = 'nb_visits'
-    display_name = _('Visits')
-
-    def get_value(self):
-        pass
-
-
-class DatasetVisits(VisitsMetric):
-    model = Dataset
-
-
-class ResourceVisits(VisitsMetric):
-    model = Resource
-
-
-class CommunityResourceVisits(VisitsMetric):
-    model = CommunityResource
-
-
-class ReuseVisits(VisitsMetric):
-    model = Reuse
-
-
-class OrganizationVisits(VisitsMetric):
-    model = Organization
-
-
-class UserVisits(VisitsMetric):
-    model = User
-
-
-class VisitorsMetric(Metric):
-    name = 'nb_uniq_visitors'
-    display_name = _('Visitors')
-
-    def get_value(self):
-        pass
-
-
-class DatasetVisitors(VisitorsMetric):
-    model = Dataset
-
-
-class ResourceVisitors(VisitorsMetric):
-    model = Resource
-
-
-class CommunityResourceVisitors(VisitorsMetric):
-    model = CommunityResource
-
-
-class ReuseVisitors(VisitorsMetric):
-    model = Reuse
-
-
-class OrganizationVisitors(VisitorsMetric):
-    model = Organization
-
-
-class UserVisitors(VisitorsMetric):
-    model = User
 
 
 class ViewsMetric(Metric):
@@ -211,12 +113,6 @@ def upsert_metric_for_day(obj, day, data):
     oid = obj.id if hasattr(obj, 'id') else obj
     if not isinstance(day, basestring):
         day = (day or date.today()).isoformat()
-
-    if hasattr(obj, 'metrics') and day == date.today().isoformat():
-        # Update object current metrics
-        for k in KEYS:
-            obj.metrics[k] = data[k]
-
     commands = dict(('inc__values__{0}'.format(k), data[k]) for k in KEYS)
     metrics = Metrics.objects(object_id=oid, level='daily', date=day)
     return metrics.update_one(upsert=True, **commands)
@@ -225,26 +121,6 @@ def upsert_metric_for_day(obj, day, data):
 def clear_metrics_for_day(day):
     if not isinstance(day, basestring):
         day = (day or date.today()).isoformat()
-
-    if is_today(day):
-        commands = dict(('set__metrics__{0}'.format(k), 0) for k in KEYS)
-        for model in Organization, Reuse, User:
-            try:
-                model.objects.update(**commands)
-            except Exception:
-                log.exception('Unable to clean %s', model.__name__)
-        for dataset in Dataset.objects:
-            dcommands = commands.copy()
-            for i, _r in enumerate(dataset.resources):
-                dcommands.update({
-                    'set__resources__{0}__metrics__{1}'.format(i, k): 0
-                    for k in KEYS
-                })
-            try:
-                dataset.update(**dcommands)
-            except Exception:
-                log.exception('Unable to clear dataset %s', dataset.id)
-
     commands = dict(('unset__values__{0}'.format(k), 1) for k in KEYS)
     metrics = Metrics.objects(level='daily', date=day)
     return metrics.update(upsert=False, **commands)

--- a/udata_piwik/metrics.py
+++ b/udata_piwik/metrics.py
@@ -72,7 +72,7 @@ class OrgResourcesDownloads(Metric):
 
     def get_value(self):
         ids = itertools.chain(*[
-            [r.id for r in d.resources or []] for d in
+            [getattr(r, 'id', None) for r in d.resources or []] for d in
             (Dataset.objects(organization=self.target).only('resources') or [])
         ])
         return int(Metrics.objects(object_id__in=ids, level='daily')

--- a/udata_piwik/metrics.py
+++ b/udata_piwik/metrics.py
@@ -72,7 +72,7 @@ class OrgResourcesDownloads(Metric):
 
     def get_value(self):
         ids = itertools.chain(*[
-            [r.id for r in d.resources] for d in
+            [r.id for r in d.resources or []] for d in
             (Dataset.objects(organization=self.target).only('resources') or [])
         ])
         return int(Metrics.objects(object_id__in=ids, level='daily')


### PR DESCRIPTION
I tried to simplify things a bit here: I removed every metric on our content objects except for `views`. This is less confusing IMHO and I don't think we need the others (we still have them on the `Metrics` objects). Plus, I do not understand how they could have been useful: they seem to have been reset each day and not incremented.

Another PR is coming on uData to make sure we only use `metrics.views`.

I also added more tests.

Added protection for a few cases which should ensure the job runs reliably (tested on live data from Piwik):
- do not crash (Exception) when no downloaded object is detected (by hash or by id)
- protect from malformed resources: `None` or `{}`

There is still some stuff I need to understand. For example, this dataset https://www.data.gouv.fr/fr/admin/dataset/53698f1aa3a729239d203653 has 1857 unique downloads in Piwik for the last year, but only 44 in our DB (currently not displayed on production). Why do we have such a discrepancy? Was the piwik job failing that often? Can we do something to get the correct data back into our DB? _Edit: I tried to recompute locally some data for the previous year but it's too slow, it takes ~1h per day_