### PR TITLE
Upgrade dependencies for 1.6+ test stack (major pytest changes)

### DIFF
--- a/requirements/develop.pip
+++ b/requirements/develop.pip
@@ -1,5 +1,5 @@
 -e .[test]
 flake8==3.5.0
-invoke==1.1.1
-pytest-cov==2.5.1
-readme-renderer==21.0
+invoke==1.2.0
+pytest-cov==2.6.0
+readme-renderer==22.0

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,1 +1,1 @@
-udata>=1.3.0
+udata>=1.6.0.dev

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -1,5 +1,5 @@
 mock==2.0.0
-pytest==3.7.4
-pytest-flask==0.11.0
+pytest==3.8.1
+pytest-flask==0.13.0
 pytest-mock==1.10.0
 retrying==1.3.3


### PR DESCRIPTION
This should make tests pass for later incoming PR