### PR TITLE
Workaround for bad transitive dependencies resolution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,9 @@ jobs:
           command: |
             virtualenv venv
             source venv/bin/activate
+            # Workaround to bad transitive dependencies resolution:
+            # Install package first then all other dependencies
+            pip install -e . || pip install -e .
             pip install -r requirements/develop.pip || pip install -r requirements/develop.pip
       - save_cache:
           key: py-cache-v1-{{ arch }}-{{ checksum "python.deps" }}


### PR DESCRIPTION
This *should* prevent pip from messing with transitive resolution: gives priority to versions defined in `udata-piwik` and `udata` over test and reporting dependencies.