### PR TITLE
Lower jobs priority to low

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,9 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
-          - py-cache-v1-{{ arch }}-{{ checksum "python.deps" }}
-          - py-cache-v1-{{ arch }}-{{ .Branch }}
-          - py-cache-v1-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+          - py-cache-v2-{{ arch }}-{{ checksum "python.deps" }}
+          - py-cache-v2-{{ arch }}-{{ .Branch }}
+          - py-cache-v2-{{ arch }}-{{ .Environment.BASE_BRANCH }}
       - run:
           name: Install python dependencies
           command: |
@@ -43,11 +43,11 @@ jobs:
             pip install -e . || pip install -e .
             pip install -r requirements/develop.pip || pip install -r requirements/develop.pip
       - save_cache:
-          key: py-cache-v1-{{ arch }}-{{ checksum "python.deps" }}
+          key: py-cache-v2-{{ arch }}-{{ checksum "python.deps" }}
           paths:
           - venv
       - save_cache:
-          key: py-cache-v1-{{ arch }}-{{ .Branch }}
+          key: py-cache-v2-{{ arch }}-{{ .Branch }}
           paths:
           - venv
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Advanced search tracking: display results count and categories (datasets, reuses, organizations) [#88](https://github.com/opendatateam/udata-piwik/pull/88)
+- Lower jobs piriority to `low` [#90](https://github.com/opendatateam/udata-piwik/pull/90)
 
 ## 1.2.0 (2018-06-06)
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,1 +1,1 @@
-udata>=1.6.0.dev
+udata>=1.6.1.dev

--- a/udata_piwik/tasks.py
+++ b/udata_piwik/tasks.py
@@ -19,7 +19,7 @@ from .counter import counter
 log = logging.getLogger(__name__)
 
 
-@job('piwik-current-metrics')
+@job('piwik-current-metrics', route='low.piwik')
 def piwik_current_metrics(self):
     '''Fetch piwik metrics for the current day'''
     day = date.today()
@@ -29,7 +29,7 @@ def piwik_current_metrics(self):
     counter.count_for(day)
 
 
-@job('piwik-yesterday-metrics')
+@job('piwik-yesterday-metrics', route='low.piwik')
 def piwik_yesterday_metrics(self):
     '''Bump piwik daily metrics for yesterday'''
     day = date.today() - timedelta(days=1)
@@ -39,14 +39,14 @@ def piwik_yesterday_metrics(self):
     counter.count_for(day)
 
 
-@connect(on_api_call)
+@connect(on_api_call, route='low.piwik')
 def piwik_track_api(url, **params):
     '''Track an API request into Piwik.'''
     log.debug('Sending to piwik: {url}'.format(url=url))
     track(url, **params)
 
 
-@connect(on_dataset_published)
+@connect(on_dataset_published, route='low.piwik')
 def piwik_track_dataset_published(url, **params):
     '''Track a dataset publication into Piwik.'''
     log.debug('Sending to piwik: {url}'.format(url=url))
@@ -58,7 +58,7 @@ def piwik_track_dataset_published(url, **params):
     track(url, **params)
 
 
-@connect(on_reuse_published)
+@connect(on_reuse_published, route='low.piwik')
 def piwik_track_reuse_published(url, **params):
     '''Track a reuse publication into Piwik.'''
     log.debug('Sending to piwik: {url}'.format(url=url))
@@ -70,7 +70,7 @@ def piwik_track_reuse_published(url, **params):
     track(url, **params)
 
 
-@connect(on_new_follow)
+@connect(on_new_follow, route='low.piwik')
 def piwik_track_new_follow(url, **params):
     '''Track a new follow into Piwik.'''
     log.debug('Sending to piwik: {url}'.format(url=url))


### PR DESCRIPTION
This PR lowers jobs priority to `low`.

To apply the same change to connected tasks, https://github.com/opendatateam/udata/pull/1908 is required.
So there is 2 possibilities:
- make the change in this PR and display dependency on udata 1.6.1
- make another PR for connected tasks (allowing to release this one without waiting for udata 1.6.1)