### PR TITLE
Wait for uData object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Ensure JS goals handling waits for `uData` object to be present
 
 ## 1.3.0 (2018-10-11)
 

--- a/udata_piwik/templates/piwik.html
+++ b/udata_piwik/templates/piwik.html
@@ -17,17 +17,6 @@
     g.defer=true; g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
   
-  {% if config.PIWIK_GOALS %}
-  var goals = {{config.PIWIK_GOALS|to_json|safe}};
-  for (var goal in goals) {
-    var value = goals[goal];
-    uData.pubsub.subscribe(goal, function () {
-      uData.log.debug('Tracking goal', goal, 'with value', value);
-      _paq.push(['trackGoal', value]);
-    });
-  }
-  {% endif %}
-  
   {% if config.PIWIK_CONTENT_TRACKING == 'all' %}
   _paq.push(['trackAllContentImpressions']);
   {% elif config.PIWIK_CONTENT_TRACKING == 'visible' %}
@@ -45,6 +34,21 @@
   {% else %}
   _paq.push(['trackPageView']);
   {% endif %}
+
+  {% if config.PIWIK_GOALS %}
+  var PIWIK_GOALS = {{config.PIWIK_GOALS|to_json|safe}};
+  // Wait for uData object to be present
+  window.addEventListener("load", function() {
+    for (var goal in PIWIK_GOALS) {
+      var value = PIWIK_GOALS[goal];
+      uData.pubsub.subscribe(goal, function () {
+        uData.log.debug('Tracking goal', goal, 'with value', value);
+        _paq.push(['trackGoal', value]);
+      });
+    }
+  }, false);
+  {% endif %}
+
 
 </script>
 <noscript><p><img src="http://{{config.PIWIK_URL}}/piwik.php?idsite={{config.PIWIK_ID}}" style="border:0;" alt="" /></p></noscript>


### PR DESCRIPTION
This PR fixes some reference errors occuring when Piwik inline js is executed before the `uData` global object is present.

See: https://sentry.data.gouv.fr/share/issue/b2ebe0bd02a44fb79211568f16ec21ee/