### PR TITLE
Add PIWIK_SCHEME config support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add `PIWIK_SCHEME` config support [#104](https://github.com/opendatateam/udata-piwik/pull/104)
 
 ## 1.3.1 (2018-11-05)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Modify your local configuration file of **udata** (typically, `udata.cfg`) as fo
 PLUGINS = ['piwik']
 # Tracked site id in Piwik
 PIWIK_ID = 1
+PIWIK_SCHEME = 'https'
 PIWIK_URL = 'stats.data.gouv.fr'
 PIWIK_AUTH = '<32-chars-auth-token-from-piwik>'
 # Mapping of piwik goals {'<name_in_udata>': <id_in_piwik>}

--- a/udata_piwik/client.py
+++ b/udata_piwik/client.py
@@ -16,7 +16,10 @@ DEFAULT_ANALYZE_TIMEOUT = 60 * 5  # in seconds
 
 def analyze(method, **kwargs):
     """Retrieve JSON stats from Piwik for a given `method` and parameters."""
-    base_url = 'http://{0}/index.php'.format(current_app.config['PIWIK_URL'])
+    base_url = '{0}://{1}/index.php'.format(
+        current_app.config.get('PIWIK_SCHEME', 'http'),
+        current_app.config['PIWIK_URL'],
+    )
     data = {
         'module': 'API',
         'idSite': current_app.config['PIWIK_ID'],
@@ -39,7 +42,10 @@ def analyze(method, **kwargs):
 
 def track(url, **kwargs):
     """Track a request to a given `url` by issuing a POST against Piwik."""
-    base_url = 'http://{0}/piwik.php'.format(current_app.config['PIWIK_URL'])
+    base_url = '{0}://{1}/piwik.php'.format(
+        current_app.config.get('PIWIK_SCHEME', 'http'),
+        current_app.config['PIWIK_URL'],
+    )
     data = {
         'rec': 1,
         'idsite': current_app.config['PIWIK_ID'],


### PR DESCRIPTION
This brings compatibility with a https-only stats server (such as the new stats.data.gouv.fr). Designed to be backward-compatible.