### PR TITLE
Consolidate and expose default settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Consolidate and expose default settings [#119](https://github.com/opendatateam/udata-piwik/pull/119)
 
 ## 1.3.2 (2019-01-14)
 

--- a/udata_piwik/client.py
+++ b/udata_piwik/client.py
@@ -8,16 +8,15 @@ from datetime import date
 
 from flask import current_app
 
-log = logging.getLogger(__name__)
+from . import settings
 
-DEFAULT_TRACK_TIMEOUT = 60  # in seconds
-DEFAULT_ANALYZE_TIMEOUT = 60 * 5  # in seconds
+log = logging.getLogger(__name__)
 
 
 def analyze(method, **kwargs):
     """Retrieve JSON stats from Piwik for a given `method` and parameters."""
     base_url = '{0}://{1}/index.php'.format(
-        current_app.config.get('PIWIK_SCHEME', 'http'),
+        current_app.config.get('PIWIK_SCHEME', settings.PIWIK_SCHEME),
         current_app.config['PIWIK_URL'],
     )
     data = {
@@ -35,7 +34,7 @@ def analyze(method, **kwargs):
         kwargs['date'] = dt
     data.update(kwargs)
     timeout = current_app.config.get('PIWIK_ANALYZE_TIMEOUT',
-                                     DEFAULT_ANALYZE_TIMEOUT)
+                                     settings.PIWIK_ANALYZE_TIMEOUT)
     r = requests.get(base_url, params=data, timeout=timeout)
     return r.json()
 
@@ -43,7 +42,7 @@ def analyze(method, **kwargs):
 def track(url, **kwargs):
     """Track a request to a given `url` by issuing a POST against Piwik."""
     base_url = '{0}://{1}/piwik.php'.format(
-        current_app.config.get('PIWIK_SCHEME', 'http'),
+        current_app.config.get('PIWIK_SCHEME', settings.PIWIK_SCHEME),
         current_app.config['PIWIK_URL'],
     )
     data = {
@@ -54,5 +53,5 @@ def track(url, **kwargs):
     }
     data.update(kwargs)
     timeout = current_app.config.get('PIWIK_TRACK_TIMEOUT',
-                                     DEFAULT_TRACK_TIMEOUT)
+                                     settings.PIWIK_TRACK_TIMEOUT)
     requests.post(base_url, data=data, timeout=timeout)

--- a/udata_piwik/settings.py
+++ b/udata_piwik/settings.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+'''
+Default settings for udata-piwik
+'''
+# Piwik/Matomo instance URL
+PIWIK_URL = None
+
+# Scheme used to make Piwik/Matomo API calls (http or https)
+PIWIK_SCHEME = 'http'
+
+# Piwik/Matomo site ID
+PIWIK_ID = 1
+
+# Authentication token from Piwik/Matomo
+PIWIK_AUTH = '<32-chars-auth-token-from-piwik>'
+
+# Piwik/Matomo Goals mapping
+# All keys are required and should exists on instance
+PIWIK_GOALS = {
+    # 'NEW_DATASET': 1,
+    # 'NEW_REUSE': 2,
+    # 'NEW_FOLLOW': 3,
+    # 'SHARE': 4,
+    # 'RESOURCE_DOWNLOAD': 5,
+    # 'RESOURCE_REDIRECT': 6,
+}
+
+# Piwik/Matomo reporting analyse timeout in seconds
+PIWIK_ANALYZE_TIMEOUT = 60 * 5
+
+# Piwik/Matomo tracking submission timeout in seconds
+PIWIK_TRACK_TIMEOUT = 60


### PR DESCRIPTION
This PR exposes default settings in `udata_piwik.settings` according to opendatateam/udata#2058

Default values have been replaced in a backward comptible way (still call `app.config.get()`) but this can be simplified when opendatateam/udata#2058 is released