### PR TITLE
Bulk API calls submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Consolidate and expose default settings [#119](https://github.com/opendatateam/udata-piwik/pull/119)
+- Process API calls in bulk [#120](https://github.com/opendatateam/udata-piwik/pull/120)
 
 ## 1.3.2 (2019-01-14)
 

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,9 @@ setup(
         'udata.commands': [
             'piwik = udata_piwik.commands:piwik',
         ],
+        'udata.models': [
+            'piwik = udata_piwik.models',
+        ],
         'udata.tasks': [
             'piwik = udata_piwik.tasks',
         ],

--- a/tests/client.py
+++ b/tests/client.py
@@ -29,7 +29,7 @@ def has_data():
     }
     r = requests.get('%s/index.php' % BASE_URL, params=data)
     data = r.json()
-    assert isinstance(data, list) and len(data)
+    assert isinstance(data, list)
     return True
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+from datetime import date, datetime
+
+
+from udata.utils import faker
+
+from udata_piwik.client import bulk_track, analyze
+
+from .conftest import PiwikSettings
+from .client import has_data, reset
+
+
+pytestmark = pytest.mark.settings.with_args(PiwikSettings)
+
+
+@pytest.fixture()
+def reset_piwik():
+    reset()
+
+
+@pytest.fixture()
+def ready(app, reset_piwik):
+    # wait for Piwik to be populated
+    assert has_data()
+
+
+def find_tracking(url, data):
+    for entry in data:
+        if entry.get('url') == url:
+            return entry
+        elif 'subtable' in entry:
+            found = find_tracking(url, entry['subtable'])
+            if found:
+                return found
+
+
+def test_bulk_track(ready):
+    urls = [('http://local.test/' + faker.uri_path(), datetime.now(), {}) for _ in range(3)]
+
+    response = bulk_track(*urls)
+
+    assert response['status'] == 'success'
+    assert response['tracked'] == len(urls)
+
+    data = analyze('Actions.getPageUrls', period='day', date=date.today(), expanded=1)
+    for (url, _, _) in urls:
+        t = find_tracking(url, data)
+        assert t is not None, 'No tracking entry found for {}'.format(url)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,7 @@ from datetime import date, datetime
 
 from udata.utils import faker
 
-from udata_piwik.client import bulk_track, analyze
+from udata_piwik.client import bulk_track, analyze, track
 
 from .conftest import PiwikSettings
 from .client import has_data, reset
@@ -36,6 +36,16 @@ def find_tracking(url, data):
             found = find_tracking(url, entry['subtable'])
             if found:
                 return found
+
+
+def test_track(ready):
+    url = 'http://local.test/' + faker.uri_path()
+
+    track(url)
+
+    data = analyze('Actions.getPageUrls', period='day', date=date.today(), expanded=1)
+    t = find_tracking(url, data)
+    assert t is not None, 'No tracking entry found for {}'.format(url)
 
 
 def test_bulk_track(ready):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -13,6 +13,7 @@ from udata.core.dataset.signals import on_dataset_published
 from udata.core.reuse.signals import on_reuse_published
 from udata.core.followers.signals import on_new_follow
 from udata.core.user.factories import UserFactory
+from udata.utils import faker
 
 from udata_piwik import tasks
 from udata_piwik.factories import PiwikTrackingFactory
@@ -64,7 +65,9 @@ def test_piwik_yesterday_metrics(counter):
 def test_piwik_track_api(track, app, clean_db):
     path = '/api/1/some/api'
     user = UserFactory()
-    with app.test_request_context(path, base_url=PREFIX):
+    ip = faker.ipv4()
+    with app.test_request_context(path, base_url=PREFIX,
+                                  environ_base={'REMOTE_ADDR': ip}):
         tracking.send_signal(on_api_call, request, user)
 
     assert not track.called
@@ -75,7 +78,7 @@ def test_piwik_track_api(track, app, clean_db):
     assert pt.date is not None
     assert pt.kwargs == {
         'uid': user.id,
-        'user_ip': None,
+        'cip': ip,
     }
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -79,7 +79,7 @@ def test_piwik_track_api(track, app, clean_db):
     }
 
 
-def test_piwik_bulk_track_api(bulk_track, clean_db):
+def test_piwik_bulk_track_api(bulk_track, clean_db, mocker):
     max_urls = 2
     total = 3
     entries = PiwikTrackingFactory.create_batch(total)
@@ -88,7 +88,7 @@ def test_piwik_bulk_track_api(bulk_track, clean_db):
 
     assert PiwikTracking.objects.count() == total - max_urls
     bulk_track.assert_called_with(*[
-        (e.url, e.kwargs)
+        (e.url, mocker.ANY, e.kwargs)
         # Chronoligical order expected
         for e in sorted(entries, key=lambda e: e.date)[:max_urls]
     ])
@@ -97,7 +97,7 @@ def test_piwik_bulk_track_api(bulk_track, clean_db):
 
     assert PiwikTracking.objects.count() == 0
     bulk_track.assert_called_with(*[
-        (e.url, e.kwargs)
+        (e.url, mocker.ANY, e.kwargs)
         # Chronoligical order expected
         for e in sorted(entries, key=lambda e: e.date)[max_urls:]
     ])

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+from datetime import date, timedelta
+
+from flask import request
+
+from udata import tracking
+from udata.api.signals import on_api_call
+from udata.core.dataset.signals import on_dataset_published
+from udata.core.reuse.signals import on_reuse_published
+from udata.core.followers.signals import on_new_follow
+from udata.core.user.factories import UserFactory
+
+from udata_piwik import tasks
+
+PREFIX = 'https://data.somewhere.com'
+GOAL_NEW_DATASET = 1
+GOAL_NEW_REUSE = 2
+GOAL_NEW_FOLLOW = 3
+
+pytestmark = pytest.mark.options(plugins=['piwik'],
+                                 piwik_goals={
+                                     'NEW_DATASET': GOAL_NEW_DATASET,
+                                     'NEW_REUSE': GOAL_NEW_REUSE,
+                                     'NEW_FOLLOW': GOAL_NEW_FOLLOW,
+                                 })
+
+
+@pytest.fixture
+def counter(mocker):
+    # Mock counter to speedup test as it is already tested elsewhere
+    return mocker.patch('udata_piwik.tasks.counter')
+    
+
+@pytest.fixture
+def track(mocker):
+    # Mock track to speedup test as it is already tested elsewhere
+    return mocker.patch('udata_piwik.tasks.track')
+
+
+def test_piwik_current_metrics(counter):
+    tasks.piwik_current_metrics()
+    counter.count_for.assert_called_with(date.today())
+
+
+def test_piwik_yesterday_metrics(counter):
+    yesterday = date.today() - timedelta(days=1)
+    tasks.piwik_yesterday_metrics()
+    counter.count_for.assert_called_with(yesterday)
+
+
+def test_piwik_track_api(track, app):
+    path = '/api/1/some/api'
+    user = UserFactory()
+    with app.test_request_context(path, base_url=PREFIX):
+        tracking.send_signal(on_api_call, request, user)
+
+    track.assert_called_with(PREFIX + path, uid=user.id, user_ip=None)
+
+
+def test_piwik_track_new_follow(track, app):
+    path = '/path/to/dataset'
+    user = UserFactory()
+    with app.test_request_context(path, base_url=PREFIX):
+        tracking.send_signal(on_new_follow, request, user)
+
+    track.assert_called_with(PREFIX + path, uid=user.id, user_ip=None, idgoal=GOAL_NEW_FOLLOW)

--- a/udata_piwik/client.py
+++ b/udata_piwik/client.py
@@ -55,3 +55,17 @@ def track(url, **kwargs):
     timeout = current_app.config.get('PIWIK_TRACK_TIMEOUT',
                                      settings.PIWIK_TRACK_TIMEOUT)
     requests.post(base_url, data=data, timeout=timeout)
+
+
+def bulk_track(*uris):
+    '''
+    Track multiple requests in one API call
+
+    Each entry should be a 2-tuple (`url`, `kwargs`) where:
+      - `url` is the request URL as string
+      - `kwargs` is a `dict` with some extras Piwik parameters
+
+    Entries should be sorted chronologicaly as piwik/matomo expect it.
+    The ordering is the caller responsibility to avoid double sorting.
+    '''
+    pass

--- a/udata_piwik/client.py
+++ b/udata_piwik/client.py
@@ -5,6 +5,7 @@ import logging
 import requests
 
 from datetime import date
+from urllib import urlencode
 
 from flask import current_app
 
@@ -57,15 +58,42 @@ def track(url, **kwargs):
     requests.post(base_url, data=data, timeout=timeout)
 
 
+def encode_for_bulk(url, dt, kwargs):
+    qs = {
+        'rec': 1,
+        'idsite': current_app.config['PIWIK_ID'],
+        'url': url,
+        'cdt': dt.strftime('%s'),
+    }
+    qs.update(kwargs)
+    return '?' + urlencode(qs)
+
+
 def bulk_track(*uris):
     '''
     Track multiple requests in one API call
 
-    Each entry should be a 2-tuple (`url`, `kwargs`) where:
+    Each entry should be a 3-tuple (`url`, `date`, `kwargs`) where:
       - `url` is the request URL as string
+      - `date` is the original request date
       - `kwargs` is a `dict` with some extras Piwik parameters
 
     Entries should be sorted chronologicaly as piwik/matomo expect it.
     The ordering is the caller responsibility to avoid double sorting.
     '''
-    pass
+    base_url = '{0}://{1}/piwik.php'.format(
+        current_app.config.get('PIWIK_SCHEME', settings.PIWIK_SCHEME),
+        current_app.config['PIWIK_URL'],
+    )
+    data = {
+        'token_auth': current_app.config['PIWIK_AUTH'],
+        'requests': [
+            encode_for_bulk(url, ts, kwargs)
+            for url, ts, kwargs in uris
+        ]
+    }
+    timeout = current_app.config.get('PIWIK_TRACK_TIMEOUT',
+                                     settings.PIWIK_TRACK_TIMEOUT)
+    resp = requests.post(base_url, json=data, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()

--- a/udata_piwik/factories.py
+++ b/udata_piwik/factories.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import factory
+
+from bson import ObjectId
+
+from udata.factories import ModelFactory
+from udata.utils import faker
+
+from .models import PiwikTracking
+
+
+class PiwikTrackingFactory(ModelFactory):
+    class Meta:
+        model = PiwikTracking
+
+    url = factory.Faker('uri')
+
+    @factory.lazy_attribute
+    def kwargs(self):
+        return {
+            'uid': ObjectId(),
+            'user_ip': faker.ipv4(),
+        }

--- a/udata_piwik/models.py
+++ b/udata_piwik/models.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from datetime import datetime
+
+from udata.models import db
+
+
+__all__ = ('PiwikTracking', )
+
+
+class PiwikTracking(db.Document):
+    url = db.URLField(required=True)
+    date = db.DateTimeField(required=True, default=datetime.now)
+    kwargs = db.DictField()
+
+    meta = {
+        'indexes': ['date'],
+        'ordering': ['date'],
+    }

--- a/udata_piwik/settings.py
+++ b/udata_piwik/settings.py
@@ -31,3 +31,7 @@ PIWIK_ANALYZE_TIMEOUT = 60 * 5
 
 # Piwik/Matomo tracking submission timeout in seconds
 PIWIK_TRACK_TIMEOUT = 60
+
+# Use bulk API calls processing
+# NB: if true, you need to schedule the `piwik-bulk-track-api` job
+PIWIK_BULK = False

--- a/udata_piwik/tasks.py
+++ b/udata_piwik/tasks.py
@@ -58,7 +58,7 @@ def piwik_bulk_track_api(self, max_urls):
     '''
     log.debug('Submitting API calls in bulk to piwik')
     tracking = PiwikTracking.objects[:max_urls]
-    bulk_track(*[(pt.url, pt.kwargs) for pt in tracking])
+    bulk_track(*[(pt.url, pt.date, pt.kwargs) for pt in tracking])
     tracking.delete()
 
 

--- a/udata_piwik/tasks.py
+++ b/udata_piwik/tasks.py
@@ -48,13 +48,17 @@ def piwik_track_api(url, **params):
 
 
 @job('piwik-bulk-track-api', route='low.piwik')
-def piwik_bulk_track_api(self):
+def piwik_bulk_track_api(self, max_urls):
+    '''
+    Submit API calls tracking in bulk.
+
+    This task should be scheduled with the max number of URLs
+    to process in the batch as sole argument
+    Adjust the couple "scheduling/max URLs" to your needs.
+    '''
     log.debug('Submitting API calls in bulk to piwik')
-    tracking = PiwikTracking.objects.all()
-    bulk_track(*[
-        (pt.url, pt.kwargs)
-        for pt in tracking
-    ])
+    tracking = PiwikTracking.objects[:max_urls]
+    bulk_track(*[(pt.url, pt.kwargs) for pt in tracking])
     tracking.delete()
 
 

--- a/udata_piwik/tasks.py
+++ b/udata_piwik/tasks.py
@@ -15,6 +15,7 @@ from udata.core.followers.signals import on_new_follow
 from .client import track, bulk_track
 from .counter import counter
 from .models import PiwikTracking
+from .settings import PIWIK_BULK as PIWIK_BULK_DEFAULT
 
 
 log = logging.getLogger(__name__)
@@ -46,7 +47,10 @@ def piwik_track_api(url, **params):
     log.debug('Sending to piwik: {url}'.format(url=url))
     if 'user_ip' in params:
         params['cip'] = params.pop('user_ip')
-    PiwikTracking.objects.create(url=url, kwargs=params)
+    if current_app.config.get('PIWIK_BULK', PIWIK_BULK_DEFAULT):
+        PiwikTracking.objects.create(url=url, kwargs=params)
+    else:
+        track(url, **params)
 
 
 @job('piwik-bulk-track-api', route='low.piwik')

--- a/udata_piwik/tasks.py
+++ b/udata_piwik/tasks.py
@@ -44,6 +44,8 @@ def piwik_yesterday_metrics(self):
 def piwik_track_api(url, **params):
     '''Track an API request into Piwik.'''
     log.debug('Sending to piwik: {url}'.format(url=url))
+    if 'user_ip' in params:
+        params['cip'] = params.pop('user_ip')
     PiwikTracking.objects.create(url=url, kwargs=params)
 
 


### PR DESCRIPTION
This PR make use of [Piwik/Matomo bulk tracking](https://developer.matomo.org/api-reference/tracking-api#bulk-tracking) to submit API calls.

Each call is stored in Mongo and then a periodic `piwik_bulk_track_api` job process this calls by batch.
The couple `periodicity`/`batch size` have to be adjusted to your volumetry.

**Fixes**
- The caller IP was being ignored (submitted under `user_ip` while Piwik/Matomo expect `cip`)

**Possible alternatives**
- Make the bulk processing opt-in (with a `PIWIK_BULK` boolean)
- Use redis instead of Mongo (but redis is optionnal)