### PR TITLE
Replaced deprecated readme-renderer by twine check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,9 +89,6 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run:
-          name: Install Twine
-          command: pip install twine
       - deploy:
           name: Publish on PyPI
           command: twine upload --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}" dist/*.whl

--- a/requirements/develop.pip
+++ b/requirements/develop.pip
@@ -2,4 +2,4 @@
 flake8==3.7.7
 invoke==1.2.0
 pytest-cov==2.6.1
-readme-renderer[md]==24.0
+twine==1.13.0

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ setup(
     version='1.3.3.dev',
     description='Piwik support for uData',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     url='https://github.com/opendatateam/udata-piwik',
     author='OpenDataTeam',
     author_email='contact@opendata.team',

--- a/tasks.py
+++ b/tasks.py
@@ -85,30 +85,23 @@ def qa(ctx):
             error('There is some lints to fix')
         else:
             success('No lint to fix')
-        info('Ensure PyPI can render README and CHANGELOG')
-        readme_results = ctx.run('python setup.py check -r -s',
-                                 pty=True, warn=True, hide=True)
-        if readme_results.failed:
-            print(readme_results.stdout)
-            error('README and/or CHANGELOG is not renderable by PyPI')
-        else:
-            success('README and CHANGELOG are renderable by PyPI')
-    if flake8_results.failed or readme_results.failed:
+    if flake8_results.failed:
         error('Quality check failed')
-        exit(flake8_results.return_code or readme_results.return_code)
+        exit(flake8_results.return_code)
     success('Quality check OK')
 
 
 @task
 def dist(ctx, buildno=None):
     '''Package for distribution'''
-    header('Building a distribuable package')
+    header('Building a distributable package')
     cmd = ['python setup.py']
     if buildno:
         cmd.append('egg_info -b {0}'.format(buildno))
     cmd.append('bdist_wheel')
     with ctx.cd(ROOT):
         ctx.run(' '.join(cmd), pty=True)
+    ctx.run('twine check dist/*')
     success('Distribution is available in dist directory')
 
 


### PR DESCRIPTION
This PR drop the `readme-renderer` check for `twine check` (which is now the [official way of locally testing packaging](https://packaging.python.org/guides/making-a-pypi-friendly-readme/#validating-restructuredtext-markup).

As a consequence Twine is now part of development dependencies (instead of `readme-renderer[md]` which was not checking anymore).

The missing `long_description_content_type` parameter has been added.