### PR TITLE
Improve detect_by_url error handling

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,7 +5,6 @@ import pytest
 
 from datetime import date, datetime
 
-
 from udata.utils import faker
 
 from udata_piwik.client import bulk_track, analyze, track

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -1,0 +1,9 @@
+from udata_piwik.download_counter import DailyDownloadCounter
+
+
+def test_detect_by_url_mismatch(app):
+    '''Check that everything is fine when detect_by_url does not match'''
+    counter = DailyDownloadCounter('2012-12-12')
+    counter.detect_by_url({'url': 'nimp'})
+    assert counter.resources == []
+    assert counter.community_resources == []

--- a/udata_piwik/download_counter.py
+++ b/udata_piwik/download_counter.py
@@ -69,32 +69,31 @@ class DailyDownloadCounter(object):
             except CommunityResource.DoesNotExist:
                 log.error('No object found for resource_id %s' % resource_id)
 
-    def detect_by_hashed_url(self, hashed_url, row):
+    def detect_by_url(self, row):
+        url = row['url']
+        hashed_url = hash_url(url)
         found = False
-        try:
-            datasets = Dataset.objects.filter(resources__urlhash=hashed_url)
-            for dataset in datasets:
-                resource = get_by(dataset.resources, 'urlhash', hashed_url)
-                self.resources.append({
-                    'dataset': dataset,
-                    'resource': resource,
-                    'data': row,
-                })
-                found = True
-        except Dataset.DoesNotExist:
-            pass
-        try:
-            resources = CommunityResource.objects.filter(urlhash=hashed_url)
-            for resource in resources:
-                self.community_resources.append({
-                    'resource': resource,
-                    'data': row,
-                })
-                found = True
-        except CommunityResource.DoesNotExist:
-            pass
+        datasets = Dataset.objects.filter(resources__urlhash=hashed_url)
+        for dataset in datasets:
+            resource = get_by(dataset.resources, 'urlhash', hashed_url)
+            self.resources.append({
+                'dataset': dataset,
+                'resource': resource,
+                'data': row,
+            })
+            found = True
+        resources = CommunityResource.objects.filter(urlhash=hashed_url)
+        for resource in resources:
+            self.community_resources.append({
+                'resource': resource,
+                'data': row,
+            })
+            found = True
         if not found:
-            log.error('No object found for urlhash %s' % hashed_url)
+            log.error('No resource found by url', extra={
+                'hashed_url': hashed_url,
+                'url': url
+            })
 
     def detect_download_objects(self):
         for row in self.rows:
@@ -105,8 +104,7 @@ class DailyDownloadCounter(object):
             if resource_id:
                 self.detect_by_resource_id(resource_id, row)
             else:
-                hashed_url = hash_url(row['url'])
-                self.detect_by_hashed_url(hashed_url, row)
+                self.detect_by_url(row)
 
     def handle_resources_downloads(self):
         for item in self.resources:


### PR DESCRIPTION
This should help debugging those errors: https://sentry.data.gouv.fr/etalab/www-datagouvfr/issues/1865326/.

Errors should now:
- be grouped
- display url instead of only the hash

This also removes some useless Exception handling when querying the DB (we're using `filter`, not `get`).