### PR TITLE
Send views data to influx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ jobs:
           MYSQL_USER: piwik
           MYSQL_PASSWORD: piwik
     environment:
-       BASH_ENV: /root/.bashrc
-       PIWIK_URL: localhost
+      BASH_ENV: /root/.bashrc
+      PIWIK_URL: localhost
     steps:
       - checkout
       - run:
@@ -30,13 +30,13 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
-          - py-cache-v2-{{ arch }}-{{ checksum "python.deps" }}
-          - py-cache-v2-{{ arch }}-{{ .Branch }}
-          - py-cache-v2-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+            - py-cache-v2-{{ arch }}-{{ checksum "python.deps" }}
+            - py-cache-v2-{{ arch }}-{{ .Branch }}
+            - py-cache-v2-{{ arch }}-{{ .Environment.BASE_BRANCH }}
       - run:
           name: Install python dependencies
           command: |
-            virtualenv -ppython3.6 venv
+            virtualenv venv
             source venv/bin/activate
             # Workaround to bad transitive dependencies resolution:
             # Install package first then all other dependencies
@@ -45,11 +45,11 @@ jobs:
       - save_cache:
           key: py-cache-v2-{{ arch }}-{{ checksum "python.deps" }}
           paths:
-          - venv
+            - venv
       - save_cache:
           key: py-cache-v2-{{ arch }}-{{ .Branch }}
           paths:
-          - venv
+            - venv
       - run:
           name: Run tests
           command: |
@@ -85,11 +85,7 @@ jobs:
 
   publish:
     docker:
-<<<<<<< HEAD
       - image: udata/circleci:2-alpine
-=======
-      - image: udata/circleci:py3
->>>>>>> Migrate to python3
     steps:
       - attach_workspace:
           at: .
@@ -101,13 +97,9 @@ jobs:
 
   github:
     docker:
-<<<<<<< HEAD
       - image: udata/circleci:2-alpine
-=======
-      - image: udata/circleci:py3
->>>>>>> Migrate to python3
     environment:
-       BASH_ENV: /root/.bashrc
+      BASH_ENV: /root/.bashrc
     steps:
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - run:
           name: Install python dependencies
           command: |
-            virtualenv venv
+            virtualenv -ppython3.6 venv
             source venv/bin/activate
             # Workaround to bad transitive dependencies resolution:
             # Install package first then all other dependencies
@@ -85,7 +85,11 @@ jobs:
 
   publish:
     docker:
+<<<<<<< HEAD
       - image: udata/circleci:2-alpine
+=======
+      - image: udata/circleci:py3
+>>>>>>> Migrate to python3
     steps:
       - attach_workspace:
           at: .
@@ -97,7 +101,11 @@ jobs:
 
   github:
     docker:
+<<<<<<< HEAD
       - image: udata/circleci:2-alpine
+=======
+      - image: udata/circleci:py3
+>>>>>>> Migrate to python3
     environment:
        BASH_ENV: /root/.bashrc
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,9 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
-            - py-cache-v2-{{ arch }}-{{ checksum "python.deps" }}
-            - py-cache-v2-{{ arch }}-{{ .Branch }}
-            - py-cache-v2-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+            - py-cache-v3-{{ arch }}-{{ checksum "python.deps" }}
+            - py-cache-v3-{{ arch }}-{{ .Branch }}
+            - py-cache-v3-{{ arch }}-{{ .Environment.BASE_BRANCH }}
       - run:
           name: Install python dependencies
           command: |
@@ -48,11 +48,11 @@ jobs:
             pip install -e . || pip install -e .
             pip install -r requirements/develop.pip || pip install -r requirements/develop.pip
       - save_cache:
-          key: py-cache-v2-{{ arch }}-{{ checksum "python.deps" }}
+          key: py-cache-v3-{{ arch }}-{{ checksum "python.deps" }}
           paths:
             - venv
       - save_cache:
-          key: py-cache-v2-{{ arch }}-{{ .Branch }}
+          key: py-cache-v3-{{ arch }}-{{ .Branch }}
           paths:
             - venv
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,9 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
-            - py-cache-v5-{{ arch }}-{{ checksum "python.deps" }}
-            - py-cache-v5-{{ arch }}-{{ .Branch }}
-            - py-cache-v5-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+            - py-cache-v6-{{ arch }}-{{ checksum "python.deps" }}
+            - py-cache-v6-{{ arch }}-{{ .Branch }}
+            - py-cache-v6-{{ arch }}-{{ .Environment.BASE_BRANCH }}
       - run:
           name: Install python dependencies
           command: |
@@ -48,11 +48,11 @@ jobs:
             pip install -e . || pip install -e .
             pip install -r requirements/develop.pip || pip install -r requirements/develop.pip
       - save_cache:
-          key: py-cache-v5-{{ arch }}-{{ checksum "python.deps" }}
+          key: py-cache-v6-{{ arch }}-{{ checksum "python.deps" }}
           paths:
             - venv
       - save_cache:
-          key: py-cache-v5-{{ arch }}-{{ .Branch }}
+          key: py-cache-v6-{{ arch }}-{{ .Branch }}
           paths:
             - venv
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,11 @@ jobs:
       - image: circleci/mongo:3.6-stretch-ram
       - image: redis:alpine
       - image: udata/elasticsearch:2.4.5
+      - image: influxdb:alpine
+        environment:
+          INFLUXDB_DB: piwik_db
+          INFLUXDB_USER: piwik
+          INFLUXDB_USER_PASSWORD: piwik
       - image: udata/piwik-test
         environment:
           MYSQL_ROOT_PASSWORD: piwik

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,9 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
-            - py-cache-v10-{{ arch }}-{{ checksum "python.deps" }}
-            - py-cache-v10-{{ arch }}-{{ .Branch }}
-            - py-cache-v10-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+            - py-cache-v11-{{ arch }}-{{ checksum "python.deps" }}
+            - py-cache-v11-{{ arch }}-{{ .Branch }}
+            - py-cache-v11-{{ arch }}-{{ .Environment.BASE_BRANCH }}
       - run:
           name: Install python dependencies
           command: |
@@ -48,11 +48,11 @@ jobs:
             pip install -e . || pip install -e .
             pip install -r requirements/develop.pip || pip install -r requirements/develop.pip
       - save_cache:
-          key: py-cache-v10-{{ arch }}-{{ checksum "python.deps" }}
+          key: py-cache-v11-{{ arch }}-{{ checksum "python.deps" }}
           paths:
             - venv
       - save_cache:
-          key: py-cache-v10-{{ arch }}-{{ .Branch }}
+          key: py-cache-v11-{{ arch }}-{{ .Branch }}
           paths:
             - venv
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,9 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
-            - py-cache-v6-{{ arch }}-{{ checksum "python.deps" }}
-            - py-cache-v6-{{ arch }}-{{ .Branch }}
-            - py-cache-v6-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+            - py-cache-v7-{{ arch }}-{{ checksum "python.deps" }}
+            - py-cache-v7-{{ arch }}-{{ .Branch }}
+            - py-cache-v7-{{ arch }}-{{ .Environment.BASE_BRANCH }}
       - run:
           name: Install python dependencies
           command: |
@@ -48,11 +48,11 @@ jobs:
             pip install -e . || pip install -e .
             pip install -r requirements/develop.pip || pip install -r requirements/develop.pip
       - save_cache:
-          key: py-cache-v6-{{ arch }}-{{ checksum "python.deps" }}
+          key: py-cache-v7-{{ arch }}-{{ checksum "python.deps" }}
           paths:
             - venv
       - save_cache:
-          key: py-cache-v6-{{ arch }}-{{ .Branch }}
+          key: py-cache-v7-{{ arch }}-{{ .Branch }}
           paths:
             - venv
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,9 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
-            - py-cache-v9-{{ arch }}-{{ checksum "python.deps" }}
-            - py-cache-v9-{{ arch }}-{{ .Branch }}
-            - py-cache-v9-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+            - py-cache-v10-{{ arch }}-{{ checksum "python.deps" }}
+            - py-cache-v10-{{ arch }}-{{ .Branch }}
+            - py-cache-v10-{{ arch }}-{{ .Environment.BASE_BRANCH }}
       - run:
           name: Install python dependencies
           command: |
@@ -48,11 +48,11 @@ jobs:
             pip install -e . || pip install -e .
             pip install -r requirements/develop.pip || pip install -r requirements/develop.pip
       - save_cache:
-          key: py-cache-v9-{{ arch }}-{{ checksum "python.deps" }}
+          key: py-cache-v10-{{ arch }}-{{ checksum "python.deps" }}
           paths:
             - venv
       - save_cache:
-          key: py-cache-v9-{{ arch }}-{{ .Branch }}
+          key: py-cache-v10-{{ arch }}-{{ .Branch }}
           paths:
             - venv
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,9 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
-            - py-cache-v3-{{ arch }}-{{ checksum "python.deps" }}
-            - py-cache-v3-{{ arch }}-{{ .Branch }}
-            - py-cache-v3-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+            - py-cache-v4-{{ arch }}-{{ checksum "python.deps" }}
+            - py-cache-v4-{{ arch }}-{{ .Branch }}
+            - py-cache-v4-{{ arch }}-{{ .Environment.BASE_BRANCH }}
       - run:
           name: Install python dependencies
           command: |
@@ -48,11 +48,11 @@ jobs:
             pip install -e . || pip install -e .
             pip install -r requirements/develop.pip || pip install -r requirements/develop.pip
       - save_cache:
-          key: py-cache-v3-{{ arch }}-{{ checksum "python.deps" }}
+          key: py-cache-v4-{{ arch }}-{{ checksum "python.deps" }}
           paths:
             - venv
       - save_cache:
-          key: py-cache-v3-{{ arch }}-{{ .Branch }}
+          key: py-cache-v4-{{ arch }}-{{ .Branch }}
           paths:
             - venv
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,9 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
-            - py-cache-v7-{{ arch }}-{{ checksum "python.deps" }}
-            - py-cache-v7-{{ arch }}-{{ .Branch }}
-            - py-cache-v7-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+            - py-cache-v8-{{ arch }}-{{ checksum "python.deps" }}
+            - py-cache-v8-{{ arch }}-{{ .Branch }}
+            - py-cache-v8-{{ arch }}-{{ .Environment.BASE_BRANCH }}
       - run:
           name: Install python dependencies
           command: |
@@ -48,11 +48,11 @@ jobs:
             pip install -e . || pip install -e .
             pip install -r requirements/develop.pip || pip install -r requirements/develop.pip
       - save_cache:
-          key: py-cache-v7-{{ arch }}-{{ checksum "python.deps" }}
+          key: py-cache-v8-{{ arch }}-{{ checksum "python.deps" }}
           paths:
             - venv
       - save_cache:
-          key: py-cache-v7-{{ arch }}-{{ .Branch }}
+          key: py-cache-v8-{{ arch }}-{{ .Branch }}
           paths:
             - venv
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,9 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
-            - py-cache-v4-{{ arch }}-{{ checksum "python.deps" }}
-            - py-cache-v4-{{ arch }}-{{ .Branch }}
-            - py-cache-v4-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+            - py-cache-v5-{{ arch }}-{{ checksum "python.deps" }}
+            - py-cache-v5-{{ arch }}-{{ .Branch }}
+            - py-cache-v5-{{ arch }}-{{ .Environment.BASE_BRANCH }}
       - run:
           name: Install python dependencies
           command: |
@@ -48,11 +48,11 @@ jobs:
             pip install -e . || pip install -e .
             pip install -r requirements/develop.pip || pip install -r requirements/develop.pip
       - save_cache:
-          key: py-cache-v4-{{ arch }}-{{ checksum "python.deps" }}
+          key: py-cache-v5-{{ arch }}-{{ checksum "python.deps" }}
           paths:
             - venv
       - save_cache:
-          key: py-cache-v4-{{ arch }}-{{ .Branch }}
+          key: py-cache-v5-{{ arch }}-{{ .Branch }}
           paths:
             - venv
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,9 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
-            - py-cache-v8-{{ arch }}-{{ checksum "python.deps" }}
-            - py-cache-v8-{{ arch }}-{{ .Branch }}
-            - py-cache-v8-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+            - py-cache-v9-{{ arch }}-{{ checksum "python.deps" }}
+            - py-cache-v9-{{ arch }}-{{ .Branch }}
+            - py-cache-v9-{{ arch }}-{{ .Environment.BASE_BRANCH }}
       - run:
           name: Install python dependencies
           command: |
@@ -48,11 +48,11 @@ jobs:
             pip install -e . || pip install -e .
             pip install -r requirements/develop.pip || pip install -r requirements/develop.pip
       - save_cache:
-          key: py-cache-v8-{{ arch }}-{{ checksum "python.deps" }}
+          key: py-cache-v9-{{ arch }}-{{ checksum "python.deps" }}
           paths:
             - venv
       - save_cache:
-          key: py-cache-v8-{{ arch }}-{{ .Branch }}
+          key: py-cache-v9-{{ arch }}-{{ .Branch }}
           paths:
             - venv
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,9 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
-            - py-cache-v11-{{ arch }}-{{ checksum "python.deps" }}
-            - py-cache-v11-{{ arch }}-{{ .Branch }}
-            - py-cache-v11-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+            - py-cache-v12-{{ arch }}-{{ checksum "python.deps" }}
+            - py-cache-v12-{{ arch }}-{{ .Branch }}
+            - py-cache-v12-{{ arch }}-{{ .Environment.BASE_BRANCH }}
       - run:
           name: Install python dependencies
           command: |
@@ -48,11 +48,11 @@ jobs:
             pip install -e . || pip install -e .
             pip install -r requirements/develop.pip || pip install -r requirements/develop.pip
       - save_cache:
-          key: py-cache-v11-{{ arch }}-{{ checksum "python.deps" }}
+          key: py-cache-v12-{{ arch }}-{{ checksum "python.deps" }}
           paths:
             - venv
       - save_cache:
-          key: py-cache-v11-{{ arch }}-{{ .Branch }}
+          key: py-cache-v12-{{ arch }}-{{ .Branch }}
           paths:
             - venv
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Current (in progress)
 
-- Changed metrics system. They are now stored in influxDB [#185](https://github.com/opendatateam/udata-piwik/pull/185)
+- Changed metrics system [#185](https://github.com/opendatateam/udata-piwik/pull/185):
+  - Metrics are now stored into InfluxDB before being injected in udata's objects.
+  - Udata piwik accesses influxDB throught [udata-metrics](https://github.com/opendatateam/udata-metrics)
+  - For the metrics injection, a periodic job needs to be scheduled, and a command was added to trigger it manually
 
 ## 2.0.2 (2020-04-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Migrate to python3 🐍 [#68](https://github.com/opendatateam/udata-piwik/pull/68)
 
 ## 2.0.2 (2020-04-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Migrate to python3 🐍 [#68](https://github.com/opendatateam/udata-piwik/pull/68)
+- Migrate footer snippet to the new `footer.snippets` hook [#157](https://github.com/opendatateam/udata-piwik/pull/157)
 
 ## 2.0.2 (2020-04-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## Current (in progress)
 
 - Changed metrics system [#185](https://github.com/opendatateam/udata-piwik/pull/185):
-  - Metrics are now stored into InfluxDB before being injected in udata's objects.
+  - Metrics are now stored into InfluxDB before being injected in udata's objects
   - Udata piwik accesses influxDB throught [udata-metrics](https://github.com/opendatateam/udata-metrics)
-  - For the metrics injection, a periodic job needs to be scheduled, and a command was added to trigger it manually
+  - The periodic job `piwik-update-metrics` needs to be scheduled in addition to existing jobs, in order to retrieve the views metrics in udata's objects
+  - The command `update-metrics` was added to trigger the metrics injection manually
 
 ## 2.0.2 (2020-04-24)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,13 @@ services:
       MYSQL_DATABASE: piwik
       MYSQL_USER: piwik
       MYSQL_PASSWORD: piwik
+  influx:
+    image: influxdb:alpine
+    ports:
+      - "8086:8086"
+    environment:
+      INFLUXDB_DB: piwik_db
+      INFLUXDB_ADMIN_USER: piwik_admin
+      INFLUXDB_ADMIN_PASSWORD: piwik_admin
+      INFLUXDB_USER: piwik
+      INFLUXDB_USER_PASSWORD: piwik

--- a/requirements/develop.pip
+++ b/requirements/develop.pip
@@ -2,4 +2,4 @@
 flake8==3.7.7
 invoke==1.2.0
 pytest-cov==2.6.1
-twine==1.13.0
+twine==3.1.1

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,2 +1,1 @@
 udata>=2.0.0.dev
-influxdb

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,2 +1,2 @@
-udata>=2.0.0.dev
-udata-metrics>=0.1.1.dev
+udata>=2.1.0
+udata-metrics>=1.0.0

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,1 +1,2 @@
 udata>=2.0.0.dev
+udata-metrics>=0.1.1.dev

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,1 +1,1 @@
-udata>=2.0.0
+udata>=2.0.0.dev

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,1 +1,2 @@
 udata>=2.0.0.dev
+influxdb

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ tests_require = pip('test.pip')
 
 setup(
     name='udata-piwik',
-    version='2.0.0.dev',
+    version='2.0.3.dev',
     description='Piwik support for uData',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -81,11 +81,7 @@ setup(
         'Topic :: System :: Software Distribution',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-<<<<<<< HEAD
         'Programming Language :: Python :: 3.7',
-=======
-        'Programming Language :: Python :: 3.6',
->>>>>>> Migrate to python3
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ tests_require = pip('test.pip')
 
 setup(
     name='udata-piwik',
-    version='2.0.3.dev',
+    version='2.0.0.dev',
     description='Piwik support for uData',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -81,7 +81,11 @@ setup(
         'Topic :: System :: Software Distribution',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+<<<<<<< HEAD
         'Programming Language :: Python :: 3.7',
+=======
+        'Programming Language :: Python :: 3.6',
+>>>>>>> Migrate to python3
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,3 +17,10 @@ class PiwikSettings(Testing):
         'RESOURCE_DOWNLOAD': 5,
         'RESOURCE_REDIRECT': 6,
     }
+    METRICS_DSN = {
+        'host': 'localhost',
+        'port': '8086',
+        'username': 'piwik',
+        'password': 'piwik',
+        'database': 'piwik_db'
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from udata.settings import Testing
 
 
 class PiwikSettings(Testing):
-    PLUGINS = ['piwik']
+    PLUGINS = ['piwik', 'metrics']
     PIWIK_ID_FRONT = 1
     PIWIK_ID_API = 2
     PIWIK_URL = os.environ.get('PIWIK_URL', 'localhost:8080')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 
 from datetime import date, datetime

--- a/tests/test_piwik.py
+++ b/tests/test_piwik.py
@@ -148,30 +148,33 @@ def test_dataset_metric(fixtures):
     client = metrics_client_factory()
     result = client.get_views_from_specific_model('dataset', fixtures['dataset'].id)
     values = next(result.get_points())
+
     assert values['nb_hits'] == 2
     assert values['nb_uniq_visitors'] == 1
     assert values['nb_visits'] == 1
+
     fixtures['dataset'].reload()
     assert fixtures['dataset'].get_metrics()['views'] == 1
 
 
-# def test_resource_metric(fixtures):
-#     metrics_resource = Metrics.objects.get_for(fixtures['resource'])
-#     metric = metrics_resource[0]
-#     assert metric.level == 'daily'
-#     assert metric.date == date.today().isoformat()
-#     # 1 hit on permalink, 1 on url
-#     assert metric.values == {'nb_hits': 2, 'nb_uniq_visitors': 2,
-#         'nb_visits': 2}
-#     fixtures['dataset'].reload()
-#     resource = fixtures['dataset'].resources[0]
-#     assert resource.metrics == {'views': 2}
+def test_resource_metric(fixtures):
+    client = metrics_client_factory()
+    result = client.get_views_from_specific_model('resource', fixtures['dataset'].id)
+    values = next(result.get_points())
+    # 1 hit on permalink, 1 on url
+    assert values['nb_hits'] == 2
+    assert values['nb_uniq_visitors'] == 2
+    assert values['nb_visits'] == 2
+
+    fixtures['dataset'].reload()
+    resource = fixtures['dataset'].resources[0]
+    assert resource.get_metrics()['views'] == 2
 
 
-# def test_resource_metric_with_previous_data(fixtures):
-#     fixtures['dataset_w_previous_data'].reload()
-#     resource = fixtures['dataset_w_previous_data'].resources[0]
-#     assert resource.metrics == {'views': 17}
+def test_resource_metric_with_previous_data(fixtures):
+    fixtures['dataset_w_previous_data'].reload()
+    resource = fixtures['dataset_w_previous_data'].resources[0]
+    assert resource.get_metrics()['views'] == 17
 
 
 # def test_community_resource_metric(fixtures):
@@ -183,7 +186,7 @@ def test_dataset_metric(fixtures):
 #     assert metric.values == {'nb_hits': 2, 'nb_uniq_visitors': 2,
 #         'nb_visits': 2}
 #     fixtures['community_resource'].reload()
-#     assert fixtures['community_resource'].metrics['views'] == 2
+#     assert fixtures['community_resource'].get_metrics()['views'] == 2
 
 
 # def test_two_datasets_one_resource_url(fixtures):

--- a/tests/test_piwik.py
+++ b/tests/test_piwik.py
@@ -14,6 +14,8 @@ from udata.core.user.factories import UserFactory
 
 from udata.tests.plugin import drop_db
 
+from udata_metrics.client import metrics_client_factory
+
 from udata_piwik.counter import counter
 from udata_piwik.upsert import upsert_metric_for_resource
 
@@ -142,34 +144,15 @@ def fixtures(app, reset_piwik, dataset_resource, organization,
     }
 
 
-def test_objects_have_metrics(fixtures):
-    # XXX is this list exhaustive?
-    metrics_dataset = fixtures['dataset'].get_metrics()
-    print(metrics_dataset)
-    assert False
-    # metrics_dataset = Metrics.objects.get_for(fixtures['dataset'])
-    # assert len(metrics_dataset) == 1
-    # metrics_org = Metrics.objects.get_for(fixtures['organization'])
-    # assert len(metrics_org) == 1
-    # metrics_user = Metrics.objects.get_for(fixtures['user'])
-    # assert len(metrics_user) == 1
-    # metrics_reuse = Metrics.objects.get_for(fixtures['reuse'])
-    # assert len(metrics_reuse) == 1
-    # metrics_resource = Metrics.objects.get_for(fixtures['resource'])
-    # assert len(metrics_resource) == 1
-    # metrics_comres = Metrics.objects.get_for(fixtures['community_resource'])
-    # assert len(metrics_comres) == 1
-
-
-# def test_dataset_metric(fixtures):
-#     metrics_dataset = Metrics.objects.get_for(fixtures['dataset'])
-#     metric = metrics_dataset[0]
-#     assert metric.level == 'daily'
-#     assert metric.date == date.today().isoformat()
-#     assert metric.values == {'nb_hits': 2, 'nb_uniq_visitors': 1,
-#         'nb_visits': 1}
-#     fixtures['dataset'].reload()
-#     assert fixtures['dataset'].metrics['views'] == 1
+def test_dataset_metric(fixtures):
+    client = metrics_client_factory()
+    result = client.get_views_from_specific_model('dataset', fixtures['dataset'].id)
+    values = next(result.get_points())
+    assert values['nb_hits'] == 2
+    assert values['nb_uniq_visitors'] == 1
+    assert values['nb_visits'] == 1
+    fixtures['dataset'].reload()
+    assert fixtures['dataset'].get_metrics()['views'] == 1
 
 
 # def test_resource_metric(fixtures):

--- a/tests/test_piwik.py
+++ b/tests/test_piwik.py
@@ -132,6 +132,7 @@ def fixtures(app, reset_piwik, dataset_resource, organization,
     dataset, resource = dataset_resource
     d_w_previous_data, r_w_previous_data = dataset_resource_w_previous_data
     return {
+        'app': app,
         'dataset': dataset,
         'organization': organization,
         'resource': resource,
@@ -175,6 +176,7 @@ def test_resource_metric(fixtures):
 
 
 def test_resource_metric_with_previous_data(fixtures):
+    update_datasets_metrics_from_backend()
     update_resources_metrics_from_backend()
     fixtures['dataset_w_previous_data'].reload()
     resource = fixtures['dataset_w_previous_data'].resources[0]

--- a/tests/test_piwik.py
+++ b/tests/test_piwik.py
@@ -4,7 +4,6 @@ from datetime import date, datetime, timedelta
 
 from udata import frontend, settings
 from udata.app import create_app
-from udata.core.metrics.models import Metrics
 from udata.core.dataset.factories import (
     DatasetFactory, ResourceFactory, CommunityResourceFactory
 )
@@ -16,7 +15,7 @@ from udata.core.user.factories import UserFactory
 from udata.tests.plugin import drop_db
 
 from udata_piwik.counter import counter
-from udata_piwik.metrics import upsert_metric_for_day
+from udata_piwik.upsert import upsert_metric_for_resource
 
 from .conftest import PiwikSettings
 from .client import visit, has_data, reset, download
@@ -56,10 +55,10 @@ def dataset_resource_w_previous_data(app):
     dataset = DatasetFactory(resources=[resource])
     day = datetime.now() - timedelta(days=1)
     data = {'nb_uniq_visitors': 5, 'nb_hits': 5, 'nb_visits': 5}
-    upsert_metric_for_day(resource, day, data)
+    upsert_metric_for_resource(resource, dataset, day, data)
     day = datetime.now() - timedelta(days=2)
     data = {'nb_uniq_visitors': 10, 'nb_hits': 10, 'nb_visits': 10}
-    upsert_metric_for_day(resource, day, data)
+    upsert_metric_for_resource(resource, dataset, day, data)
     visit(dataset)
     download(resource)
     download(resource, latest=True)
@@ -145,72 +144,75 @@ def fixtures(app, reset_piwik, dataset_resource, organization,
 
 def test_objects_have_metrics(fixtures):
     # XXX is this list exhaustive?
-    metrics_dataset = Metrics.objects.get_for(fixtures['dataset'])
-    assert len(metrics_dataset) == 1
-    metrics_org = Metrics.objects.get_for(fixtures['organization'])
-    assert len(metrics_org) == 1
-    metrics_user = Metrics.objects.get_for(fixtures['user'])
-    assert len(metrics_user) == 1
-    metrics_reuse = Metrics.objects.get_for(fixtures['reuse'])
-    assert len(metrics_reuse) == 1
-    metrics_resource = Metrics.objects.get_for(fixtures['resource'])
-    assert len(metrics_resource) == 1
-    metrics_comres = Metrics.objects.get_for(fixtures['community_resource'])
-    assert len(metrics_comres) == 1
+    metrics_dataset = fixtures['dataset'].get_metrics()
+    print(metrics_dataset)
+    assert False
+    # metrics_dataset = Metrics.objects.get_for(fixtures['dataset'])
+    # assert len(metrics_dataset) == 1
+    # metrics_org = Metrics.objects.get_for(fixtures['organization'])
+    # assert len(metrics_org) == 1
+    # metrics_user = Metrics.objects.get_for(fixtures['user'])
+    # assert len(metrics_user) == 1
+    # metrics_reuse = Metrics.objects.get_for(fixtures['reuse'])
+    # assert len(metrics_reuse) == 1
+    # metrics_resource = Metrics.objects.get_for(fixtures['resource'])
+    # assert len(metrics_resource) == 1
+    # metrics_comres = Metrics.objects.get_for(fixtures['community_resource'])
+    # assert len(metrics_comres) == 1
 
 
-def test_dataset_metric(fixtures):
-    metrics_dataset = Metrics.objects.get_for(fixtures['dataset'])
-    metric = metrics_dataset[0]
-    assert metric.level == 'daily'
-    assert metric.date == date.today().isoformat()
-    assert metric.values == {'nb_hits': 2, 'nb_uniq_visitors': 1,
-        'nb_visits': 1}
-    fixtures['dataset'].reload()
-    assert fixtures['dataset'].metrics['views'] == 1
+# def test_dataset_metric(fixtures):
+#     metrics_dataset = Metrics.objects.get_for(fixtures['dataset'])
+#     metric = metrics_dataset[0]
+#     assert metric.level == 'daily'
+#     assert metric.date == date.today().isoformat()
+#     assert metric.values == {'nb_hits': 2, 'nb_uniq_visitors': 1,
+#         'nb_visits': 1}
+#     fixtures['dataset'].reload()
+#     assert fixtures['dataset'].metrics['views'] == 1
 
 
-def test_resource_metric(fixtures):
-    metrics_resource = Metrics.objects.get_for(fixtures['resource'])
-    metric = metrics_resource[0]
-    assert metric.level == 'daily'
-    assert metric.date == date.today().isoformat()
-    # 1 hit on permalink, 1 on url
-    assert metric.values == {'nb_hits': 2, 'nb_uniq_visitors': 2,
-        'nb_visits': 2}
-    fixtures['dataset'].reload()
-    resource = fixtures['dataset'].resources[0]
-    assert resource.metrics == {'views': 2}
+# def test_resource_metric(fixtures):
+#     metrics_resource = Metrics.objects.get_for(fixtures['resource'])
+#     metric = metrics_resource[0]
+#     assert metric.level == 'daily'
+#     assert metric.date == date.today().isoformat()
+#     # 1 hit on permalink, 1 on url
+#     assert metric.values == {'nb_hits': 2, 'nb_uniq_visitors': 2,
+#         'nb_visits': 2}
+#     fixtures['dataset'].reload()
+#     resource = fixtures['dataset'].resources[0]
+#     assert resource.metrics == {'views': 2}
 
 
-def test_resource_metric_with_previous_data(fixtures):
-    fixtures['dataset_w_previous_data'].reload()
-    resource = fixtures['dataset_w_previous_data'].resources[0]
-    assert resource.metrics == {'views': 17}
+# def test_resource_metric_with_previous_data(fixtures):
+#     fixtures['dataset_w_previous_data'].reload()
+#     resource = fixtures['dataset_w_previous_data'].resources[0]
+#     assert resource.metrics == {'views': 17}
 
 
-def test_community_resource_metric(fixtures):
-    metrics_resource = Metrics.objects.get_for(fixtures['community_resource'])
-    metric = metrics_resource[0]
-    assert metric.level == 'daily'
-    assert metric.date == date.today().isoformat()
-    # 1 hit on permalink, 1 on url
-    assert metric.values == {'nb_hits': 2, 'nb_uniq_visitors': 2,
-        'nb_visits': 2}
-    fixtures['community_resource'].reload()
-    assert fixtures['community_resource'].metrics['views'] == 2
+# def test_community_resource_metric(fixtures):
+#     metrics_resource = Metrics.objects.get_for(fixtures['community_resource'])
+#     metric = metrics_resource[0]
+#     assert metric.level == 'daily'
+#     assert metric.date == date.today().isoformat()
+#     # 1 hit on permalink, 1 on url
+#     assert metric.values == {'nb_hits': 2, 'nb_uniq_visitors': 2,
+#         'nb_visits': 2}
+#     fixtures['community_resource'].reload()
+#     assert fixtures['community_resource'].metrics['views'] == 2
 
 
-def test_two_datasets_one_resource_url(fixtures):
-    (d1, d2), (r1, r2) = fixtures['two_datasets_one_resource_url']
-    metrics_r1 = Metrics.objects.get_for(r1)
-    assert len(metrics_r1) == 1
-    metrics_r2 = Metrics.objects.get_for(r2)
-    assert len(metrics_r2) == 1
-    # hit once by resource_1 hashed_url, never by resource_2 latest url rid
-    assert metrics_r1[0].values == {'nb_hits': 1, 'nb_uniq_visitors': 1,
-        'nb_visits': 1}
-    # hit once by resource_1 hashed_url and once by latest url resource id
-    # ideally this should be only one but impossible to tell
-    assert metrics_r2[0].values == {'nb_hits': 2, 'nb_uniq_visitors': 2,
-        'nb_visits': 2}
+# def test_two_datasets_one_resource_url(fixtures):
+#     (d1, d2), (r1, r2) = fixtures['two_datasets_one_resource_url']
+#     metrics_r1 = Metrics.objects.get_for(r1)
+#     assert len(metrics_r1) == 1
+#     metrics_r2 = Metrics.objects.get_for(r2)
+#     assert len(metrics_r2) == 1
+#     # hit once by resource_1 hashed_url, never by resource_2 latest url rid
+#     assert metrics_r1[0].values == {'nb_hits': 1, 'nb_uniq_visitors': 1,
+#         'nb_visits': 1}
+#     # hit once by resource_1 hashed_url and once by latest url resource id
+#     # ideally this should be only one but impossible to tell
+#     assert metrics_r2[0].values == {'nb_hits': 2, 'nb_uniq_visitors': 2,
+#         'nb_visits': 2}

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 
 from datetime import date, timedelta

--- a/udata_piwik/commands.py
+++ b/udata_piwik/commands.py
@@ -7,6 +7,7 @@ from datetime import date, timedelta
 from udata.commands import cli, success
 
 from .counter import counter
+from .metrics import update_metrics_from_backend
 
 
 log = logging.getLogger(__name__)
@@ -54,3 +55,9 @@ def fill(start, end):
         current_date += timedelta(days=1)
 
     success('Loaded all metrics for the period')
+
+
+@piwik.command()
+def update_metrics():
+    '''Update instance's metrics from backend'''
+    update_metrics_from_backend()

--- a/udata_piwik/commands.py
+++ b/udata_piwik/commands.py
@@ -6,8 +6,8 @@ from datetime import date, timedelta
 
 from udata.commands import cli, success
 
-from .counter import counter
-from .metrics import update_metrics_from_backend
+from udata_piwik.counter import counter
+from udata_piwik.metrics import update_metrics_from_backend
 
 
 log = logging.getLogger(__name__)

--- a/udata_piwik/counter.py
+++ b/udata_piwik/counter.py
@@ -27,7 +27,9 @@ class Counter(object):
         return wrapper
 
     def count_for(self, day):
+        log.debug('Counting views...')
         self.count_views(day)
+        log.debug('Counting downloads...')
         dl_counter = DailyDownloadCounter(day)
         dl_counter.count()
 
@@ -38,6 +40,7 @@ class Counter(object):
             'expanded': 1
         }
         for row in analyze('Actions.getPageUrls', **params):
+            log.debug('Got views data...')
             self.handle_views(row, day)
 
     def handle_views(self, row, day):

--- a/udata_piwik/counter.py
+++ b/udata_piwik/counter.py
@@ -4,13 +4,13 @@ from werkzeug.exceptions import NotFound
 
 from udata.models import User, Organization, Reuse, Dataset
 
-from .client import analyze
-from .download_counter import DailyDownloadCounter
-from .upsert import (
+from udata_piwik.client import analyze
+from udata_piwik.download_counter import DailyDownloadCounter
+from udata_piwik.upsert import (
     upsert_metric_for_dataset, upsert_metric_for_reuse,
     upsert_metric_for_organization, upsert_metric_for_user,
 )
-from .utils import route_from, RouteNotFound
+from udata_piwik.utils import route_from, RouteNotFound
 
 log = logging.getLogger(__name__)
 

--- a/udata_piwik/counter.py
+++ b/udata_piwik/counter.py
@@ -6,7 +6,7 @@ from udata.models import User, Organization, Reuse, Dataset
 
 from .client import analyze
 from .download_counter import DailyDownloadCounter
-from .metrics import (
+from .upsert import (
     upsert_metric_for_dataset, upsert_metric_for_reuse,
     upsert_metric_for_organization, upsert_metric_for_user,
 )

--- a/udata_piwik/counter.py
+++ b/udata_piwik/counter.py
@@ -7,7 +7,6 @@ from udata.models import User, Organization, Reuse, Dataset
 from .client import analyze
 from .download_counter import DailyDownloadCounter
 from .metrics import (
-    aggregate_datasets_daily, aggregate_reuses_daily,
     upsert_metric_for_dataset, upsert_metric_for_reuse,
     upsert_metric_for_organization, upsert_metric_for_user,
 )
@@ -66,16 +65,12 @@ counter = Counter()
 def on_dataset_display(data, day, dataset, **kwargs):
     if isinstance(dataset, Dataset):
         upsert_metric_for_dataset(dataset, day, data)
-        if dataset.organization:
-            aggregate_datasets_daily(dataset.organization, day)
 
 
 @counter.route('reuses.show')
 def on_reuse_display(data, day, reuse, **kwargs):
     if isinstance(reuse, Reuse):
         upsert_metric_for_reuse(reuse, day, data)
-        if reuse.organization:
-            aggregate_reuses_daily(reuse.organization, day)
 
 
 @counter.route('organizations.show')

--- a/udata_piwik/counter.py
+++ b/udata_piwik/counter.py
@@ -7,11 +7,11 @@ from udata.models import User, Organization, Reuse, Dataset
 from .client import analyze
 from .download_counter import DailyDownloadCounter
 from .metrics import (
-    DatasetViews, ReuseViews, OrganizationViews, UserViews, OrgDatasetsViews,
-    OrgReusesViews, aggregate_datasets_daily, aggregate_reuses_daily,
-    upsert_metric_for_day, clear_metrics_for_day,
+    aggregate_datasets_daily, aggregate_reuses_daily,
+    upsert_metric_for_dataset, upsert_metric_for_reuse,
+    upsert_metric_for_organization, upsert_metric_for_user,
 )
-from .utils import is_today, route_from, RouteNotFound
+from .utils import route_from, RouteNotFound
 
 log = logging.getLogger(__name__)
 
@@ -28,7 +28,6 @@ class Counter(object):
         return wrapper
 
     def count_for(self, day):
-        clear_metrics_for_day(day)
         self.count_views(day)
         dl_counter = DailyDownloadCounter(day)
         dl_counter.count()
@@ -66,52 +65,26 @@ counter = Counter()
 @counter.route('datasets.show')
 def on_dataset_display(data, day, dataset, **kwargs):
     if isinstance(dataset, Dataset):
-        upsert_metric_for_day(dataset, day, data)
-        if is_today(day):
-            try:
-                dataset.save()
-            except Exception:
-                log.exception('Unable to save dataset %s', dataset.id)
-        DatasetViews(dataset).compute()
+        upsert_metric_for_dataset(dataset, day, data)
         if dataset.organization:
-            OrgDatasetsViews(dataset.organization).compute()
             aggregate_datasets_daily(dataset.organization, day)
 
 
 @counter.route('reuses.show')
 def on_reuse_display(data, day, reuse, **kwargs):
     if isinstance(reuse, Reuse):
-        upsert_metric_for_day(reuse, day, data)
-        if is_today(day):
-            try:
-                reuse.save()
-            except Exception:
-                log.exception('Unable to save reuse %s', reuse.id)
-        ReuseViews(reuse).compute()
+        upsert_metric_for_reuse(reuse, day, data)
         if reuse.organization:
-            OrgReusesViews(reuse.organization).compute()
             aggregate_reuses_daily(reuse.organization, day)
 
 
 @counter.route('organizations.show')
 def on_org_display(data, day, org, **kwargs):
     if isinstance(org, Organization):
-        upsert_metric_for_day(org, day, data)
-        if is_today(day):
-            try:
-                org.save()
-            except Exception:
-                log.exception('Unable to save organization %s', org.id)
-        OrganizationViews(org).compute()
+        upsert_metric_for_organization(org, day, data)
 
 
 @counter.route('users.show')
 def on_user_display(data, day, user, **kwargs):
     if isinstance(user, User):
-        upsert_metric_for_day(user, day, data)
-        if is_today(day):
-            try:
-                user.save()
-            except Exception:
-                log.exception('Unable to save user %s', user.id)
-        UserViews(user).compute()
+        upsert_metric_for_user(user, day, data)

--- a/udata_piwik/download_counter.py
+++ b/udata_piwik/download_counter.py
@@ -5,8 +5,8 @@ import uuid
 from udata.models import Dataset, CommunityResource
 from udata.utils import hash_url, get_by
 
-from .client import analyze
-from .upsert import upsert_metric_for_resource
+from udata_piwik.client import analyze
+from udata_piwik.upsert import upsert_metric_for_resource
 
 log = logging.getLogger(__name__)
 

--- a/udata_piwik/download_counter.py
+++ b/udata_piwik/download_counter.py
@@ -6,7 +6,7 @@ from udata.models import Dataset, CommunityResource
 from udata.utils import hash_url, get_by
 
 from udata_piwik.client import analyze
-from udata_piwik.upsert import upsert_metric_for_resource
+from udata_piwik.upsert import upsert_metric_for_resource, upsert_metric_for_community_resource
 
 log = logging.getLogger(__name__)
 
@@ -61,6 +61,7 @@ class DailyDownloadCounter(object):
                 'dataset': dataset,
                 'resource': resource,
                 'data': row,
+                'latest': True,
             })
         except Dataset.DoesNotExist:
             try:
@@ -68,6 +69,7 @@ class DailyDownloadCounter(object):
                 self.community_resources.append({
                     'resource': resource,
                     'data': row,
+                    'latest': True,
                 })
             except CommunityResource.DoesNotExist:
                 log.error('No object found for resource_id %s' % resource_id)
@@ -114,13 +116,15 @@ class DailyDownloadCounter(object):
             row = item['data']
             dataset = item['dataset']
             resource = item['resource']
+            latest = item.get('latest', False)
             log.debug('Found resource download: %s', resource.url)
-            upsert_metric_for_resource(resource, dataset, self.day, row)
+            upsert_metric_for_resource(resource, dataset, self.day, row, latest)
 
     def handle_community_resources_downloads(self):
         for item in self.community_resources:
             row = item['data']
             resource = item['resource']
+            latest = item.get('latest', False)
             log.debug('Found community resource download: %s',
                       resource.url)
-            upsert_metric_for_resource(resource, resource.dataset, self.day, row)
+            upsert_metric_for_community_resource(resource, resource.dataset, self.day, row, latest)

--- a/udata_piwik/download_counter.py
+++ b/udata_piwik/download_counter.py
@@ -6,7 +6,7 @@ from udata.models import Dataset, CommunityResource
 from udata.utils import hash_url, get_by
 
 from .client import analyze
-from .metrics import upsert_metric_for_resource
+from .upsert import upsert_metric_for_resource
 
 log = logging.getLogger(__name__)
 

--- a/udata_piwik/download_counter.py
+++ b/udata_piwik/download_counter.py
@@ -22,9 +22,13 @@ class DailyDownloadCounter(object):
         self.community_resources = []
 
     def count(self):
+        log.debug('Populate rows...')
         self.populate_rows()
+        log.debug('Detect download objects...')
         self.detect_download_objects()
+        log.debug('Handle resources downloads...')
         self.handle_resources_downloads()
+        log.debug('Handle community resource downloads...')
         self.handle_community_resources_downloads()
 
     def get_rows(self, rows):
@@ -41,12 +45,17 @@ class DailyDownloadCounter(object):
             'date': self.day,
             'expanded': 1
         }
+        log.debug('Getting downloads data...')
         self.get_rows(analyze('Actions.getDownloads', **params))
+        log.debug('Getting outlinks data...')
         self.get_rows(analyze('Actions.getOutlinks', **params))
 
     def detect_by_resource_id(self, resource_id, row):
         try:
-            dataset = Dataset.objects.get(resources__id=resource_id)
+            # use filter().first() to avoid double matches errors
+            dataset = Dataset.objects.filter(resources__id=resource_id).first()
+            if not dataset:
+                raise Dataset.DoesNotExist
             resource = get_by(dataset.resources, 'id', uuid.UUID(resource_id))
             self.resources.append({
                 'dataset': dataset,

--- a/udata_piwik/factories.py
+++ b/udata_piwik/factories.py
@@ -5,7 +5,7 @@ from bson import ObjectId
 from udata.factories import ModelFactory
 from udata.utils import faker
 
-from .models import PiwikTracking
+from udata_piwik.models import PiwikTracking
 
 
 class PiwikTrackingFactory(ModelFactory):

--- a/udata_piwik/factories.py
+++ b/udata_piwik/factories.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import factory
 
 from bson import ObjectId

--- a/udata_piwik/metrics.py
+++ b/udata_piwik/metrics.py
@@ -6,9 +6,7 @@ from datetime import date, time, datetime
 from flask import current_app
 from influxdb import InfluxDBClient
 
-from udata.core.metrics.models import Metrics
 from udata.core.dataset.models import Dataset, get_resource
-from udata.models import Reuse, CommunityResource
 
 KEYS = 'nb_uniq_visitors nb_hits nb_visits'.split()
 
@@ -44,12 +42,21 @@ def update_resources_metrics_from_backend():
         values = next(_values)
         values.pop('time')
         resource_id = keys['resource']
-        resource_id = uuid.UUID(resource_id)
-        resource = get_resource(resource_id)
+        try:
+            resource_id = uuid.UUID(resource_id)
+            resource = get_resource(resource_id)
+        except Exception as e:
+            log.exception(e)
+            continue
         if resource:
             log.debug('Found resource %s: %s', resource.id, values)
             resource.metrics.update(values)
-            resource.save()
+            try:
+                # TODO: disable signals
+                resource.save()
+            except Exception as e:
+                log.exception(e)
+                continue
         else:
             log.error('Resource not found - id %s', resource_id)
 
@@ -73,12 +80,20 @@ def update_datasets_metrics_from_backend():
         if dataset:
             log.debug('Found dataset %s: %s', dataset.id, values)
             dataset.metrics.update(values)
-            dataset.save()
+            try:
+                # TODO: disable signals
+                dataset.save()
+            except Exception as e:
+                log.exception(e)
+                continue
         else:
             log.error('Dataset not found - id %s', dataset_id)
 
 
 def upsert_metric_for_resource(resource, dataset, day, data):
+    if not dataset:
+        log.error('No dataset linked to resource %s', resource.id)
+        return
     author_type, author = ('organization', dataset.organization) \
         if dataset.organization else ('user', dataset.owner)
     upsert_in_metrics_backend(
@@ -101,8 +116,8 @@ def upsert_metric_for_dataset(dataset, day, data):
         day=day,
         metric='dataset_views',
         tags={
-            'author_type': author_type,
-            'author': author.id,
+            'author_type': author_type if author else None,
+            'author': author.id if author else None,
             'dataset': dataset.id,
         },
         data=data,
@@ -116,8 +131,8 @@ def upsert_metric_for_reuse(reuse, day, data):
         day=day,
         metric='reuse_views',
         tags={
-            'author_type': author_type,
-            'author': author.id,
+            'author_type': author_type if author else None,
+            'author': author.id if author else None,
             'reuse': reuse.id,
         },
         data=data,

--- a/udata_piwik/metrics.py
+++ b/udata_piwik/metrics.py
@@ -29,7 +29,7 @@ def process_metrics_result(result, model):
 
         if model_result:
             log.debug(f'Found {model_str} {model_result.id}: {values}')
-            model_result.metrics.update(values)
+            model_result.metrics['views'] = values['sum_nb_visits']
             try:
                 model_result.save(signal_kwargs={'ignores': ['post_save']})
             except Exception as e:
@@ -60,7 +60,7 @@ def update_resources_metrics_from_backend():
             continue
         if resource:
             log.debug('Found resource %s: %s', resource.id, values)
-            resource.metrics.update(values)
+            resource.metrics['views'] = values['sum_nb_visits']
             try:
                 resource.save(signal_kwargs={'ignores': ['post_save']})
             except Exception as e:

--- a/udata_piwik/metrics.py
+++ b/udata_piwik/metrics.py
@@ -47,7 +47,7 @@ def update_resources_metrics_from_backend():
     '''
     log.info('Updating resources metrics from backend...')
     client = metrics_client_factory()
-    result = client.get_views_from_all_datasets()
+    result = client.get_views_from_all_resources()
     for (_, keys), _values in result.items():
         values = next(_values)
         values.pop('time')

--- a/udata_piwik/metrics.py
+++ b/udata_piwik/metrics.py
@@ -3,7 +3,7 @@ import uuid
 
 from udata_metrics.client import metrics_client_factory
 
-from udata.core.dataset.models import Dataset, get_resource
+from udata.core.dataset.models import Dataset, get_resource, CommunityResource
 from udata.models import Reuse, User, Organization
 
 
@@ -11,8 +11,9 @@ log = logging.getLogger(__name__)
 
 
 def update_metrics_from_backend():
-    update_resources_metrics_from_backend()
     update_datasets_metrics_from_backend()
+    update_resources_metrics_from_backend()
+    update_community_resources_metrics_from_backend()
     update_reuses_metrics_from_backend()
     update_organizations_metrics_from_backend()
     update_users_metrics_from_backend()
@@ -68,6 +69,18 @@ def update_resources_metrics_from_backend():
                 continue
         else:
             log.error('Resource not found - id %s', resource_id)
+
+
+def update_community_resources_metrics_from_backend():
+    '''
+    Update community resource's metrics from backend.
+    Get a sum of all metrics for `community_resource_views` on the backend and
+    attach them to `community_resource.metrics`.
+    '''
+    log.info('Updating community resources metrics from backend...')
+    client = metrics_client_factory()
+    result = client.get_views_from_all_community_resources()
+    process_metrics_result(result, CommunityResource)
 
 
 def update_datasets_metrics_from_backend():

--- a/udata_piwik/metrics.py
+++ b/udata_piwik/metrics.py
@@ -1,16 +1,10 @@
 import logging
 import uuid
 
-from datetime import date, time, datetime
-
-from flask import current_app
-
 from udata_metrics import metrics_client_factory
 
 from udata.core.dataset.models import Dataset, get_resource
 from udata.models import Reuse, User, Organization
-
-KEYS = 'nb_uniq_visitors nb_hits nb_visits'.split()
 
 
 log = logging.getLogger(__name__)

--- a/udata_piwik/metrics.py
+++ b/udata_piwik/metrics.py
@@ -1,91 +1,17 @@
-import itertools
 import logging
 
-from datetime import date
+from datetime import date, time, datetime
 
-from udata.core.metrics import Metric
+from flask import current_app
+from influxdb import InfluxDBClient
+
 from udata.core.metrics.models import Metrics
-from udata.i18n import lazy_gettext as _
-
-from udata.models import (
-    User, Organization, Reuse, Dataset, Resource, CommunityResource
-)
+from udata.models import Reuse, Dataset
 
 KEYS = 'nb_uniq_visitors nb_hits nb_visits'.split()
 
 
 log = logging.getLogger(__name__)
-
-
-class ViewsMetric(Metric):
-    name = 'views'
-    display_name = _('Views')
-
-    def get_value(self):
-        return int(Metrics.objects(object_id=self.target.id, level='daily')
-                          .sum('values.nb_uniq_visitors'))
-
-
-class DatasetViews(ViewsMetric):
-    model = Dataset
-
-
-class ResourceViews(ViewsMetric):
-    model = Resource
-
-
-class CommunityResourceViews(ViewsMetric):
-    model = CommunityResource
-
-
-class ReuseViews(ViewsMetric):
-    model = Reuse
-
-
-class OrganizationViews(ViewsMetric):
-    model = Organization
-
-
-class UserViews(ViewsMetric):
-    model = User
-
-
-class OrgDatasetsViews(Metric):
-    model = Organization
-    name = 'dataset_views'
-    display_name = _('Datasets views')
-
-    def get_value(self):
-        ids = [d.id for d in
-               (Dataset.objects(organization=self.target).only('id') or [])]
-        return int(Metrics.objects(object_id__in=ids, level='daily')
-                          .sum('values.nb_uniq_visitors'))
-
-
-class OrgResourcesDownloads(Metric):
-    model = Organization
-    name = 'resource_downloads'
-    display_name = _('Resources downloads')
-
-    def get_value(self):
-        ids = itertools.chain(*[
-            [getattr(r, 'id', None) for r in d.resources or []] for d in
-            (Dataset.objects(organization=self.target).only('resources') or [])
-        ])
-        return int(Metrics.objects(object_id__in=ids, level='daily')
-                          .sum('values.nb_uniq_visitors'))
-
-
-class OrgReusesViews(Metric):
-    model = Organization
-    name = 'reuse_views'
-    display_name = _('Reuses views')
-
-    def get_value(self):
-        ids = [d.id for d in
-               (Reuse.objects(organization=self.target).only('id') or [])]
-        return int(Metrics.objects(object_id__in=ids, level='daily')
-                          .sum('values.nb_uniq_visitors'))
 
 
 def aggregate_datasets_daily(org, day):
@@ -106,18 +32,85 @@ def aggregate_reuses_daily(org, day):
     Metrics.objects.update_daily(org, day, **dict(zip(keys, values)))
 
 
-def upsert_metric_for_day(obj, day, data):
-    oid = obj.id if hasattr(obj, 'id') else obj
-    if not isinstance(day, str):
-        day = (day or date.today()).isoformat()
-    commands = dict(('inc__values__{0}'.format(k), data[k]) for k in KEYS)
-    metrics = Metrics.objects(object_id=oid, level='daily', date=day)
-    return metrics.update_one(upsert=True, **commands)
+def upsert_metric_for_resource(resource, dataset, day, data):
+    author_type, author = ('organization', dataset.organization) \
+        if dataset.organization else ('user', dataset.owner)
+    upsert_in_metrics_backend(
+        day=day,
+        metric='resource_views',
+        tags={
+            'author_type': author_type if author else None,
+            'author': author.id if author else None,
+            'dataset': dataset.id,
+            'resource': resource.id,
+        },
+        data=data,
+    )
 
 
-def clear_metrics_for_day(day):
-    if not isinstance(day, str):
-        day = (day or date.today()).isoformat()
-    commands = dict(('unset__values__{0}'.format(k), 1) for k in KEYS)
-    metrics = Metrics.objects(level='daily', date=day)
-    return metrics.update(upsert=False, **commands)
+def upsert_metric_for_dataset(dataset, day, data):
+    author_type, author = ('organization', dataset.organization) \
+        if dataset.organization else ('user', dataset.owner)
+    upsert_in_metrics_backend(
+        day=day,
+        metric='dataset_views',
+        tags={
+            'author_type': author_type,
+            'author': author.id,
+            'dataset': dataset.id,
+        },
+        data=data,
+    )
+
+
+def upsert_metric_for_reuse(reuse, day, data):
+    author_type, author = ('organization', reuse.organization) \
+        if reuse.organization else ('user', reuse.owner)
+    upsert_in_metrics_backend(
+        day=day,
+        metric='reuse_views',
+        tags={
+            'author_type': author_type,
+            'author': author.id,
+            'reuse': reuse.id,
+        },
+        data=data,
+    )
+
+
+def upsert_metric_for_organization(org, day, data):
+    upsert_in_metrics_backend(
+        day=day,
+        metric='organization_views',
+        tags={
+            'organization': org.id,
+        },
+        data=data,
+    )
+
+
+def upsert_metric_for_user(user, day, data):
+    upsert_in_metrics_backend(
+        day=day,
+        metric='user_views',
+        tags={
+            'user': user.id,
+        },
+        data=data,
+    )
+
+
+def upsert_in_metrics_backend(day=None, metric=None, tags={}, data={}):
+    if isinstance(day, str):
+        day = date.fromisoformat(day)
+    # we're on a daily basis, but backend is not
+    dt = datetime.combine(day or date.today(), time())
+    dsn = current_app.config['METRICS_DSN']
+    client = InfluxDBClient(**dsn)
+    body = {
+        'time': dt,
+        'measurement': metric,
+        'tags': tags,
+        'fields': dict((k, data[k]) for k in KEYS)
+    }
+    client.write_points([body])

--- a/udata_piwik/metrics.py
+++ b/udata_piwik/metrics.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 
 from datetime import date, time, datetime
 
@@ -6,7 +7,8 @@ from flask import current_app
 from influxdb import InfluxDBClient
 
 from udata.core.metrics.models import Metrics
-from udata.models import Reuse, Dataset
+from udata.core.dataset.models import Dataset, get_resource
+from udata.models import Reuse, CommunityResource
 
 KEYS = 'nb_uniq_visitors nb_hits nb_visits'.split()
 
@@ -14,7 +16,35 @@ KEYS = 'nb_uniq_visitors nb_hits nb_visits'.split()
 log = logging.getLogger(__name__)
 
 
-def aggregate_datasets_daily(org, day):
+def get_backend_client():
+    dsn = current_app.config['METRICS_DSN']
+    return InfluxDBClient(**dsn)
+
+
+def update_metrics_from_backend():
+    update_resources_metrics_from_backend()
+    # TODO other objects
+
+
+def update_resources_metrics_from_backend():
+    '''Update resources' metrics from backend'''
+    client = get_backend_client()
+    query = 'select sum(*) from resource_views group by dataset, resource;'
+    result = client.query(query)
+    for (_, keys), _values in result.items():
+        values = next(_values)
+        values.pop('time')
+        resource_id = uuid.UUID(resource_id)
+        resource = get_resource(resource_id)
+        if resource:
+            print(dataset_id, resource.id, values)
+            resource.metrics.update(values)
+            resource.save()
+        else:
+            log.error(f'Resource not found - id {resource_id}, dataset {dataset_id}')
+
+
+def aggregate_organization_datasets_daily(org, day):
     keys = ['datasets_{0}'.format(k) for k in KEYS]
     ids = [d.id for d in Dataset.objects(organization=org).only('id')]
     metrics = Metrics.objects(object_id__in=ids,
@@ -23,7 +53,7 @@ def aggregate_datasets_daily(org, day):
     return Metrics.objects.update_daily(org, day, **dict(zip(keys, values)))
 
 
-def aggregate_reuses_daily(org, day):
+def aggregate_organization_reuses_daily(org, day):
     keys = ['reuses_{0}'.format(k) for k in KEYS]
     ids = [r.id for r in Reuse.objects(organization=org).only('id')]
     metrics = Metrics.objects(object_id__in=ids,
@@ -105,8 +135,7 @@ def upsert_in_metrics_backend(day=None, metric=None, tags={}, data={}):
         day = date.fromisoformat(day)
     # we're on a daily basis, but backend is not
     dt = datetime.combine(day or date.today(), time())
-    dsn = current_app.config['METRICS_DSN']
-    client = InfluxDBClient(**dsn)
+    client = get_backend_client()
     body = {
         'time': dt,
         'measurement': metric,

--- a/udata_piwik/metrics.py
+++ b/udata_piwik/metrics.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 
-from udata_metrics import metrics_client_factory
+from udata_metrics.client import metrics_client_factory
 
 from udata.core.dataset.models import Dataset, get_resource
 from udata.models import Reuse, User, Organization

--- a/udata_piwik/models.py
+++ b/udata_piwik/models.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from datetime import datetime
 
 from udata.models import db

--- a/udata_piwik/models.py
+++ b/udata_piwik/models.py
@@ -15,8 +15,3 @@ class PiwikTracking(db.Document):
         'indexes': ['date'],
         'ordering': ['date'],
     }
-
-
-class PiwikSyncJobs(db.Document):
-    start_date = db.DateTimeField(required=True, default=datetime.now)
-    end_date = db.DateTimeField()

--- a/udata_piwik/models.py
+++ b/udata_piwik/models.py
@@ -18,3 +18,8 @@ class PiwikTracking(db.Document):
         'indexes': ['date'],
         'ordering': ['date'],
     }
+
+
+class PiwikSyncJobs(db.Document):
+    start_date = db.DateTimeField(required=True, default=datetime.now)
+    end_date = db.DateTimeField()

--- a/udata_piwik/settings.py
+++ b/udata_piwik/settings.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 '''
 Default settings for udata-piwik
 '''

--- a/udata_piwik/tasks.py
+++ b/udata_piwik/tasks.py
@@ -9,10 +9,10 @@ from udata.core.dataset.signals import on_dataset_published
 from udata.core.reuse.signals import on_reuse_published
 from udata.core.followers.signals import on_new_follow
 
-from .client import track, bulk_track
-from .counter import counter
-from .models import PiwikTracking
-from .settings import PIWIK_BULK as PIWIK_BULK_DEFAULT
+from udata_piwik.client import track, bulk_track
+from udata_piwik.counter import counter
+from udata_piwik.models import PiwikTracking
+from udata_piwik.settings import PIWIK_BULK as PIWIK_BULK_DEFAULT
 
 
 log = logging.getLogger(__name__)

--- a/udata_piwik/tasks.py
+++ b/udata_piwik/tasks.py
@@ -12,10 +12,17 @@ from udata.core.followers.signals import on_new_follow
 from udata_piwik.client import track, bulk_track
 from udata_piwik.counter import counter
 from udata_piwik.models import PiwikTracking
+from udata_piwik.metrics import update_metrics_from_backend
 from udata_piwik.settings import PIWIK_BULK as PIWIK_BULK_DEFAULT
 
 
 log = logging.getLogger(__name__)
+
+
+@job('piwik-update-metrics', route='low.piwik')
+def piwik_update_metrics(self):
+    '''Update udata objects metrics'''
+    update_metrics_from_backend()
 
 
 @job('piwik-current-metrics', route='low.piwik')

--- a/udata_piwik/upsert.py
+++ b/udata_piwik/upsert.py
@@ -1,0 +1,84 @@
+def upsert_metric_for_resource(resource, dataset, day, data):
+    if not dataset:
+        log.error('No dataset linked to resource %s', resource.id)
+        return
+    author_type, author = ('organization', dataset.organization) \
+        if dataset.organization else ('user', dataset.owner)
+    upsert_in_metrics_backend(
+        day=day,
+        metric='resource_views',
+        tags={
+            'author_type': author_type if author else None,
+            'author': author.id if author else None,
+            'dataset': dataset.id,
+            'resource': resource.id,
+        },
+        data=data,
+    )
+
+
+def upsert_metric_for_dataset(dataset, day, data):
+    author_type, author = ('organization', dataset.organization) \
+        if dataset.organization else ('user', dataset.owner)
+    upsert_in_metrics_backend(
+        day=day,
+        metric='dataset_views',
+        tags={
+            'author_type': author_type if author else None,
+            'author': author.id if author else None,
+            'dataset': dataset.id,
+        },
+        data=data,
+    )
+
+
+def upsert_metric_for_reuse(reuse, day, data):
+    author_type, author = ('organization', reuse.organization) \
+        if reuse.organization else ('user', reuse.owner)
+    upsert_in_metrics_backend(
+        day=day,
+        metric='reuse_views',
+        tags={
+            'author_type': author_type if author else None,
+            'author': author.id if author else None,
+            'reuse': reuse.id,
+        },
+        data=data,
+    )
+
+
+def upsert_metric_for_organization(org, day, data):
+    upsert_in_metrics_backend(
+        day=day,
+        metric='organization_views',
+        tags={
+            'organization': org.id,
+        },
+        data=data,
+    )
+
+
+def upsert_metric_for_user(user, day, data):
+    upsert_in_metrics_backend(
+        day=day,
+        metric='user_views',
+        tags={
+            'user': user.id,
+        },
+        data=data,
+    )
+
+
+def upsert_in_metrics_backend(day=None, metric=None, tags={}, data={}):
+    if isinstance(day, str):
+        day = date.fromisoformat(day)
+    # we're on a daily basis, but backend is not
+    dt = datetime.combine(day or date.today(), time())
+    client = metrics_client_factory()
+    body = {
+        'time': dt,
+        'measurement': metric,
+        'tags': tags,
+        'fields': dict((k, data[k]) for k in KEYS)
+    }
+    client.insert(body)

--- a/udata_piwik/upsert.py
+++ b/udata_piwik/upsert.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import date, time, datetime
 
-from udata_metrics import metrics_client_factory
+from udata_metrics.client import metrics_client_factory
 
 
 KEYS = 'nb_uniq_visitors nb_hits nb_visits'.split()

--- a/udata_piwik/upsert.py
+++ b/udata_piwik/upsert.py
@@ -10,21 +10,43 @@ KEYS = 'nb_uniq_visitors nb_hits nb_visits'.split()
 log = logging.getLogger(__name__)
 
 
-def upsert_metric_for_resource(resource, dataset, day, data):
+def upsert_metric_for_resource(resource, dataset, day, data, latest=False):
     if not dataset:
         log.error('No dataset linked to resource %s', resource.id)
         return
     author_type, author = ('organization', dataset.organization) \
         if dataset.organization else ('user', dataset.owner)
+    tags = {
+        'author_type': author_type if author else None,
+        'author': author.id if author else None,
+        'dataset': dataset.id,
+        'resource': resource.id,
+    }
+    if latest:
+        tags.update({'latest_url': 'true'})
     upsert_in_metrics_backend(
         day=day,
         metric='resource_views',
-        tags={
-            'author_type': author_type if author else None,
-            'author': author.id if author else None,
-            'dataset': dataset.id,
-            'resource': resource.id,
-        },
+        tags=tags,
+        data=data,
+    )
+
+
+def upsert_metric_for_community_resource(com_resource, dataset, day, data, latest=False):
+    author_type, author = ('organization', com_resource.organization) \
+        if com_resource.organization else ('user', com_resource.owner)
+    tags = {
+        'author_type': author_type if author else None,
+        'author': author.id if author else None,
+        'dataset': dataset.id if dataset else None,
+        'communityresource': com_resource.id,
+    }
+    if latest:
+        tags.update({'latest_url': 'true'})
+    upsert_in_metrics_backend(
+        day=day,
+        metric='community_resource_views',
+        tags=tags,
         data=data,
     )
 

--- a/udata_piwik/upsert.py
+++ b/udata_piwik/upsert.py
@@ -1,3 +1,15 @@
+import logging
+from datetime import date, time, datetime
+
+from udata_metrics import metrics_client_factory
+
+
+KEYS = 'nb_uniq_visitors nb_hits nb_visits'.split()
+
+
+log = logging.getLogger(__name__)
+
+
 def upsert_metric_for_resource(resource, dataset, day, data):
     if not dataset:
         log.error('No dataset linked to resource %s', resource.id)

--- a/udata_piwik/upsert.py
+++ b/udata_piwik/upsert.py
@@ -97,7 +97,7 @@ def upsert_metric_for_user(user, day, data):
         day=day,
         metric='user_views',
         tags={
-            'user': user.id,
+            'user_view': user.id,
         },
         data=data,
     )


### PR DESCRIPTION
This is a first draft for sending views/download data from Matomo to InfluxDB.

On a local env w/ a prod DB, this command should fill the `resource_views` collection for the past few days (don't forget to configure udata to query Matomo on prod):

```
udata piwik fill -s 2020-04-01
```

The other collections won't be filled because the routes don't match (I think) eg `https://dev.local:7000/datasets/example` vs `https://www.data.gouv.fr/datasets/example` in Matomo.

This job can be run as often as needed, in practice it will perform an **upsert** on the considered day/object in Influxdb with the latest data (https://github.com/influxdata/influxdb/issues/2575#issuecomment-102071093).

Needed conf in `udata.cfg`

```
METRICS_DSN = {
    'host': 'example.com',
    'port': '8086',
    'database': 'database',
    'username': None,
    'password': None,
}
```

```
$ influx
> select * from resource_views limit 10
name: resource_views
time                author                   author_type  dataset                  nb_hits nb_uniq_visitors nb_visits resource
----                ------                   -----------  -------                  ------- ---------------- --------- --------
1583020800000000000 534fff3ea3a7292c64a774e4 user         5bc35259634f41122d982759 7       4                5         4b13bbf2-4185-4143-92d3-8ed5d990b0fa
1583020800000000000                                       536993cca3a729239d2042b9 41      23               23        c10205bb-0782-4799-b6f5-5d48d19883dd
1583020800000000000 534fff3ea3a7292c64a774e4 user         5bc35259634f41122d982759 15      5                6         9ae80de2-a41e-4282-b9f8-61e6850ef449
1583020800000000000 534fff41a3a7292c64a7772a user         539a6d53a3a7293bc272838d 8       5                5         c1eb4472-3f14-45f5-98fa-d6a0d336d01a
1583020800000000000 534fff41a3a7292c64a7772a user         547738bcc751df6b1372f5d6 13      12               12        55cd803a-998d-4a5c-9741-4cd0ee0a7699
1583020800000000000 534fff4ca3a7292c64a77c95 organization 53ba4c07a3a729219b7bead3 7       7                7         da84abee-6038-43ea-b316-cdaea2514f66
1583020800000000000 534fff4da3a7292c64a77c9f organization 53698e90a3a729239d2034d3 1       1                1         33c65a14-60c4-43f9-9f9e-8bc39d7fb25c
1583020800000000000 534fff4da3a7292c64a77c9f organization 53698e90a3a729239d2034d4 35      20               20        7dc6e4a1-2d9e-4de5-b514-9422aa8695d7
1583020800000000000 534fff50a3a7292c64a77cc0 organization 5369a15fa3a729239d2065b7 9       5                5         29ae6590-5b62-42f1-aae7-228f0ab34f76
1583020800000000000 534fff50a3a7292c64a77cc0 organization 5369a15fa3a729239d2065b7 8       7                7         696d1968-a2ef-41b0-a7c6-007a3bdd960d
```