### PR TITLE
Eliminate `udata-front` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Eliminate unnecessary `udata-front` dependency [#288](https://github.com/opendatateam/udata-piwik/pull/288)
+- Eliminate explicit `udata-front` dependency [#288](https://github.com/opendatateam/udata-piwik/pull/288)
 
 ## 4.1.0 (2024-04-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Eliminate unnecessary `udata-front` dependency [#288](https://github.com/opendatateam/udata-piwik/pull/288)
 
 ## 4.1.0 (2024-04-23)
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,2 +1,1 @@
 udata>=3.2.0
-udata-front>=1.0.0

--- a/udata_piwik/views.py
+++ b/udata_piwik/views.py
@@ -1,6 +1,6 @@
 from flask import render_template, Blueprint
 
-from udata_front.frontend import template_hook
+from udata.frontend import template_hook
 
 blueprint = Blueprint('piwik', __name__, template_folder='templates')
 


### PR DESCRIPTION
At the moment this plugin has an explicit `udata-front` dependency which makes it difficult to use it with other frontends. It seems this dependency can be eliminated.