### PR TITLE
remove protocol relative URL in template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Remove protocol URL in template when enabling tracking (scheme is now provided by `PIWIK_SCHEME`) [#289](https://github.com/opendatateam/udata-piwik/pull/289)
 
 ## 4.1.0 (2024-04-23)
 

--- a/udata_piwik/templates/piwik.html
+++ b/udata_piwik/templates/piwik.html
@@ -37,5 +37,5 @@
 
 
 </script>
-<noscript><p><img src="//{{config.PIWIK_URL}}/piwik.php?idsite={{config.PIWIK_ID_FRONT}}" style="border:0;" alt="" /></p></noscript>
+<noscript><p><img src="{{config.PIWIK_SCHEME}}://{{config.PIWIK_URL}}/piwik.php?idsite={{config.PIWIK_ID_FRONT}}" style="border:0;" alt="" /></p></noscript>
 {% endif %}


### PR DESCRIPTION
Do not use a protocol relative URL when enabling Matomo tracking (URL scheme is provided by the `PIWIK_SCHEME` configuration key).